### PR TITLE
Remove the route at /latest

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -11,17 +11,8 @@ class PeopleController < ApplicationController
     @people = all_people_with_event_counts
   end
 
-  def latest
-    csv_url = ENV.fetch("GOOGLE_FORM_CSV_URL")
-    uri = URI(csv_url)
-    form_data = Net::HTTP.get(uri)
-    plans_data = CSV.parse(form_data, headers: true)
-    plan = ResponsePlanBuilder.build(plans_data.first)
-    redirect_to person_path(plan.name)
-  end
-
   def show
-    first_name, last_name = params[:id].split
+    first_name, last_name = params[:id].titleize.split
     @person = Person.find_by(first_name: first_name, last_name: last_name)
     @events = events_for(@person)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
 Rails.application.routes.draw do
   resources :people, only: [:index, :show]
-
-  get "latest", to: "people#latest"
 end


### PR DESCRIPTION
## Problem:

We have a route at `/latest` that is no longer being used.

Previously, it would redirect the user to the most recent crisis
response plan filed. This was the location that the Google Form
redirected users to after they submitted a new response plan.

Since we are no longer using Google Forms, we have no immediate need for
a `/latest` route.
## Solution:

Since the code is unused and untested, we've removed it.
