### PR TITLE
Add response strategies (steps in a response plan)

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,6 @@
 class Person < ActiveRecord::Base
+  has_many :response_strategies
+
   def name=(value)
     (self.first_name, self.last_name) = value.split
   end

--- a/app/models/response_plan.rb
+++ b/app/models/response_plan.rb
@@ -2,7 +2,6 @@ class ResponsePlan
   include ActiveModel::Model
 
   attr_accessor(
-    :action_plan_steps,
     :city_state_zip,
     :contacts,
     :image,

--- a/app/models/response_plan_builder.rb
+++ b/app/models/response_plan_builder.rb
@@ -5,14 +5,6 @@ class ResponsePlanBuilder
   def self.build(data)
     data = data.to_h
 
-    action_plan_steps = [
-      PLACEHOLDER,
-      PLACEHOLDER,
-      PLACEHOLDER,
-      PLACEHOLDER,
-      PLACEHOLDER,
-    ].compact
-
     past_encounters = [PLACEHOLDER]
 
     preparer = {
@@ -39,7 +31,6 @@ class ResponsePlanBuilder
     needs = (data["General Services / Needs"] || "").split(",").map(&:strip)
 
     ResponsePlan.new(
-      action_plan_steps: action_plan_steps,
       city_state_zip: PLACEHOLDER,
       contacts: contacts,
       image: PLACEHOLDER_IMAGE,

--- a/app/models/response_strategy.rb
+++ b/app/models/response_strategy.rb
@@ -1,0 +1,3 @@
+class ResponseStrategy < ActiveRecord::Base
+  belongs_to :person
+end

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -53,8 +53,11 @@
         <h2>Response Plan</h2>
 
         <ol>
-          <% @plan.action_plan_steps.each do |step| %>
-            <li><%= step %></li>
+          <% @person.response_strategies.each do |strategy| %>
+            <li>
+              <h2><%= strategy.title %></h2>
+              <p><%= strategy.description %></p>
+            </li>
           <% end %>
         </ol>
       </section>

--- a/db/migrate/20160408001209_create_response_strategies.rb
+++ b/db/migrate/20160408001209_create_response_strategies.rb
@@ -1,0 +1,12 @@
+class CreateResponseStrategies < ActiveRecord::Migration
+  def change
+    create_table :response_strategies do |t|
+      t.integer :priority
+      t.string :title
+      t.text :description
+      t.references :person, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160407214453) do
+ActiveRecord::Schema.define(version: 20160408001209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,4 +46,16 @@ ActiveRecord::Schema.define(version: 20160407214453) do
     t.date     "date_of_birth"
   end
 
+  create_table "response_strategies", force: :cascade do |t|
+    t.integer  "priority"
+    t.string   "title"
+    t.text     "description"
+    t.integer  "person_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "response_strategies", ["person_id"], name: "index_response_strategies_on_person_id", using: :btree
+
+  add_foreign_key "response_strategies", "people"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,11 @@
 FactoryGirl.define do
+  factory :response_strategy do
+    priority 1
+    title "Contact case worker"
+    description "Case worker is Sam Smith at DESC"
+    person
+  end
+
   factory :person do
     name "John Doe"
     sex "M"

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -25,4 +25,15 @@ feature "Officer views a response plan" do
     expect(page).to have_content(person.eye_color)
     expect(page).to have_content(person.date_of_birth)
   end
+
+  scenario "They see the response plan steps" do
+    person = create(:person)
+    step_1 = create(:response_strategy, person: person, title: "Call case manager")
+    step_2 = create(:response_strategy, person: person, title: "Transport to Harborview")
+
+    visit person_path(person)
+
+    expect(page).to have_content(step_1.title)
+    expect(page).to have_content(step_2.title)
+  end
 end

--- a/spec/models/response_strategy_spec.rb
+++ b/spec/models/response_strategy_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ResponseStrategy, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Closes #20
## Feature:

When I'm responding to a crisis call
I want to see personalized information about how to help the person in crisis
So that I can get the best possible outcome for them.
## Implementation:

Create a `ResponseStrategy` model, which represents a single strategy that an officer can use to help a person in crisis.

Each response strategy has a priority, which is used to decide the order in which the response plans appear on the page.

At the moment, response strategies cannot be reordered.  That feature should be implemented when we build out the form interface for CRT officers.
