### PR TITLE
Dockerize the application with a database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
 # for nokogiri
 RUN apt-get install -y libxml2-dev libxslt1-dev
 
-# For capybara-webkit
-RUN apt-get install -y libqt4-webkit libqt4-dev xvfb
 RUN apt-get install -y vim
+
+ENV PHANTOM_PACKAGE phantomjs-2.1.1-linux-x86_64
+ADD https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_PACKAGE.tar.bz2 .
+RUN tar -xjf $PHANTOM_PACKAGE.tar.bz2 &&\
+      mv $PHANTOM_PACKAGE/bin/phantomjs /bin/phantomjs &&\
+      rm -r $PHANTOM_PACKAGE $PHANTOM_PACKAGE.tar.bz2
 
 ENV APP_DIR /app
 RUN mkdir $APP_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get install -y vim
 ENV APP_DIR /app
 RUN mkdir $APP_DIR
 WORKDIR $APP_DIR
-ADD Gemfile $APP_DIR/Gemfile
-ADD Gemfile.lock $APP_DIR/Gemfile.lock
+
+ADD Gemfile* $APP_DIR/
+ENV BUNDLE_PATH /box/bundle
 RUN bundle install
+
 ADD . $APP_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:latest
+
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+
+# for nokogiri
+RUN apt-get install -y libxml2-dev libxslt1-dev
+
+# For capybara-webkit
+RUN apt-get install -y libqt4-webkit libqt4-dev xvfb
+RUN apt-get install -y vim
+
+ENV APP_DIR /app
+RUN mkdir $APP_DIR
+WORKDIR $APP_DIR
+ADD Gemfile $APP_DIR/Gemfile
+ADD Gemfile.lock $APP_DIR/Gemfile.lock
+RUN bundle install
+ADD . $APP_DIR

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "rails", "~> 4.2.0"
 gem "recipient_interceptor"
 gem "sass-rails", "~> 5.0"
 gem "simple_form"
+gem "therubyracer", platforms: :ruby
 gem "title"
 gem "uglifier"
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara-webkit"
+  gem "poltergeist"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    libv8 (3.16.14.13)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -212,6 +213,7 @@ GEM
     rake (11.1.2)
     recipient_interceptor (0.1.2)
       mail
+    ref (2.0.0)
     refills (0.1.0)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
@@ -260,6 +262,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -331,6 +336,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-commands-rspec
+  therubyracer
   timecop
   title
   uglifier

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,16 +71,13 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (8.2.1)
-    capybara (2.6.2)
+    capybara (2.7.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.8.0)
-      capybara (>= 2.3.0, < 2.7.0)
-      json
     carrierwave (0.11.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -88,6 +85,7 @@ GEM
       mime-types (>= 1.16)
     chartist-rails (0.9.5)
     chronic (0.10.2)
+    cliver (0.3.2)
     cocoon (1.2.9)
     coderay (1.1.0)
     coffee-rails (4.1.1)
@@ -155,6 +153,7 @@ GEM
     minitest (5.8.4)
     momentjs-rails (2.11.1)
       railties (>= 3.1)
+    multi_json (1.11.2)
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
@@ -167,6 +166,11 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
+    poltergeist (1.9.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -286,6 +290,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -301,7 +308,6 @@ DEPENDENCIES
   bourbon (~> 4.2.0)
   bullet
   bundler-audit
-  capybara-webkit
   carrierwave
   chartist-rails
   chronic
@@ -320,6 +326,7 @@ DEPENDENCIES
   normalize-rails (~> 3.0.0)
   pg
   pg_search
+  poltergeist
   pry-byebug
   pry-rails
   puma

--- a/README.md
+++ b/README.md
@@ -102,3 +102,26 @@ programming in style.
 * [Protocol](http://github.com/thoughtbot/guides/blob/master/protocol)
 * [Best Practices](http://github.com/thoughtbot/guides/blob/master/best-practices)
 * [Style](http://github.com/thoughtbot/guides/blob/master/style)
+
+
+
+
+## Docker commands
+
+```bash
+# start by cloning the repository
+git clone git@github.com:codeforamerica/crisisresponse.git
+
+# For the first run:
+docker-compose build
+# After updating the `Dockerfile`:
+docker-compose build
+# When packaging up code for the production environment:
+docker-compose build && docker save crisis_web > build/crisis.tar
+
+
+# After updating the `Gemfile`:
+docker-compose up
+# To run the server
+docker-compose up
+```

--- a/README.md
+++ b/README.md
@@ -103,22 +103,24 @@ programming in style.
 * [Best Practices](http://github.com/thoughtbot/guides/blob/master/best-practices)
 * [Style](http://github.com/thoughtbot/guides/blob/master/style)
 
-
-
-
-## Docker commands
+## Managing Application Lifecycle
 
 ```bash
 # start by cloning the repository
 git clone git@github.com:codeforamerica/crisisresponse.git
 
-# For the first run:
+# To set up:
 docker-compose build
+docker-compose run web rake db:create db:migrate
+
+# To run the server
+docker-compose up
+
 # After updating the `Dockerfile`:
 docker-compose build
+
 # When packaging up code for the production environment:
 docker-compose build && docker save crisis_web > build/crisis.tar
-
 
 # After updating the `Gemfile`:
 docker-compose up

--- a/bin/merge
+++ b/bin/merge
@@ -1,0 +1,27 @@
+#!/usr/bin/env zsh
+
+CURRENT_BRANCH="$(git symbolic-ref HEAD --short)"
+BRANCH_NAME=${1-$CURRENT_BRANCH}
+echo "Merging branch: $BRANCH_NAME"
+
+git fetch &&\
+echo 'git checkout $BRANCH_NAME' &&\
+git checkout $BRANCH_NAME &&\
+echo 'git rebase -i origin/master' &&\
+git rebase -i origin/master &&\
+echo 'git push -f' &&\
+git push --force-with-lease &&\
+echo 'bundle exec rake' &&\
+docker-compose run web bundle exec rspec spec &&\
+echo 'git checkout master' &&\
+git checkout master &&\
+echo 'git pull' &&\
+git pull &&\
+echo 'git merge --ff-only $BRANCH_NAME' &&\
+git merge --ff-only $BRANCH_NAME &&\
+echo 'git push' &&\
+git push &&\
+echo 'git branch -d $BRANCH_NAME ' &&\
+git branch -d $BRANCH_NAME && \
+echo 'git push -f origin :$BRANCH_NAME' &&\
+git push --force-with-lease origin :$BRANCH_NAME; \

--- a/bin/serve
+++ b/bin/serve
@@ -1,1 +1,5 @@
-heroku local -e .env.local
+#!/bin/bash
+
+bundle check || bundle install
+
+bundle exec rails s -p 3000 -b 0.0.0.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
 Bundler.require(*Rails.groups)
-module VisualLog
+module CrisisResponse
   class Application < Rails::Application
     config.i18n.enforce_available_locales = true
     config.quiet_assets = true

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,9 @@ development: &default
   adapter: postgresql
   database: crisisresponse_development
   encoding: utf8
-  host: localhost
+  username: postgres
+  password:
+  host: db
   min_messages: warning
   pool: <%= Integer(ENV.fetch("DB_POOL", 5)) %>
   reaping_frequency: <%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 development: &default
   adapter: postgresql
-  database: visual_log_development
+  database: crisisresponse_development
   encoding: utf8
   host: localhost
   min_messages: warning
@@ -10,7 +10,7 @@ development: &default
 
 test:
   <<: *default
-  database: visual_log_test
+  database: crisisresponse_test
 
 production: &deploy
   encoding: utf8

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_visual_log_session'
+Rails.application.config.session_store :cookie_store, key: '_crisisresponse_session'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
         "%B %d"
 
   titles:
-    application: Visual log
+    application: Crisis Response
 
   search:
     results:

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,5 +1,5 @@
 common: &default_settings
-  app_name: "visual_log"
+  app_name: "crisisresponse"
   audit_log:
     enabled: false
   browser_monitoring:
@@ -30,5 +30,5 @@ production:
   monitor_mode: true
 staging:
   <<: *default_settings
-  app_name: "visual_log (Staging)"
+  app_name: "crisisresponse (Staging)"
   monitor_mode: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,19 @@ services:
     ports:
       - "5432:5432"
 
+  box:
+    image: busybox
+    volumes:
+      - /box
+
   web:
     build: .
-    command: bin/rails server --port 3000 --binding 0.0.0.0
+    command: ./bin/serve
     ports:
       - "3000:3000"
     links:
       - db
     volumes:
       - .:/app
+    volumes_from:
+      - box

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  db:
+    image: postgres:latest
+    ports:
+      - "5432:5432"
+
+  web:
+    build: .
+    command: bin/rails server --port 3000 --binding 0.0.0.0
+    ports:
+      - "3000:3000"
+    links:
+      - db
+    volumes:
+      - .:/app

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
 
 require "rspec/rails"
+require "capybara/poltergeist"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 
@@ -19,4 +20,5 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 end
 
+Capybara.javascript_driver = :poltergeist
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/capybara_webkit.rb
+++ b/spec/support/capybara_webkit.rb
@@ -1,5 +1,0 @@
-Capybara.javascript_driver = :webkit
-
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls
-end


### PR DESCRIPTION
Changes:

---

Update README instructions for Docker.

---

Use a data container to cache gem installs

See http://bradgessler.com/articles/docker-bundler/

---

Add a Docker environment for hosting the app

Problem:

We cannot install dependencies directly on the production environment.

Solution:

We can package up our entire development environment with Docker to avoid
manually installing dependencies one-by-one.

We're using the basic Rails Docker configuration suggested here:
https://docs.docker.com/compose/rails/

Instructions for installing `capybara-webkit`'s dependencies are here:
https://robots.thoughtbot.com/rails-on-docker

---

Change application name to `CrisisResponse`

Problem:

The name `VisualLog` was a remnant from the build week iteration of our
project. It no longer accurately describes what we're building.

Solution:

Change the application name to `CrisisResponse`.

---

Add javascript runtime

Problem:

Without a javascript runtime, some of the app's gems fail to load properly
inside docker.

Solution:

Add `therubyracer` gem, which is a default Rails javascript runtime.
