### PR TITLE
Add emergency contact information

### DIFF
--- a/app/assets/stylesheets/_people.scss
+++ b/app/assets/stylesheets/_people.scss
@@ -47,25 +47,3 @@ section.images img {
     margin-left: $base-spacing;
   }
 }
-
-.contacts {
-  @include span-columns(8 of 8);
-
-  .contact {
-    font-size: 0.8em;
-    @include span-columns(4 of 8);
-
-
-    &:nth-child(2n) {
-      @include omega;
-    }
-
-    .contact-name {
-      font-weight: bold;
-    }
-
-    .notes {
-      color: grey;
-    }
-  }
-}

--- a/app/assets/stylesheets/_section.scss
+++ b/app/assets/stylesheets/_section.scss
@@ -1,6 +1,7 @@
 $icon-size: 2.5rem;
 
 section {
+  @include fill-parent;
   background-color: white;
   border-radius: 2px;
   margin-bottom: $base-spacing;

--- a/app/assets/stylesheets/response_plan/_contacts.scss
+++ b/app/assets/stylesheets/response_plan/_contacts.scss
@@ -1,0 +1,25 @@
+.contact {
+  @include span-columns(4 of 8);
+  font-size: 0.8rem;
+
+  &:nth-child(2n) {
+    @include omega;
+  }
+}
+
+.contact-name {
+  @include heavy-font;
+  margin-bottom: $small-spacing;
+}
+
+.contact-notes {
+  @include light-font;
+  margin-top: $small-spacing;
+  opacity: 50%;
+  color: lighten($base-font-color, 25%);
+
+  &-label {
+    font-weight: 400;
+    color: $base-font-color;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def tel_to(text)
+    groups = text.to_s.scan(/(?:^\+)?\d+/)
+    link_to text, "tel:#{groups.join '-'}"
+  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,3 @@
+class Contact < ActiveRecord::Base
+  belongs_to :person
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,6 +1,7 @@
 class Person < ActiveRecord::Base
   include PgSearch
 
+  has_many :contacts
   has_many :response_strategies
 
   RACE_CODES = {

--- a/app/models/response_plan.rb
+++ b/app/models/response_plan.rb
@@ -3,7 +3,6 @@ class ResponsePlan
 
   attr_accessor(
     :city_state_zip,
-    :contacts,
     :image,
     :license_number,
     :license_state,

--- a/app/models/response_plan_builder.rb
+++ b/app/models/response_plan_builder.rb
@@ -11,24 +11,8 @@ class ResponsePlanBuilder
       team: PLACEHOLDER,
     }
 
-    contacts = [
-      {
-        name: PLACEHOLDER,
-        relationship: PLACEHOLDER,
-        phone: PLACEHOLDER,
-        notes: PLACEHOLDER,
-      },
-      {
-        name: PLACEHOLDER,
-        relationship: PLACEHOLDER,
-        phone: PLACEHOLDER,
-        notes: PLACEHOLDER,
-      },
-    ]
-
     ResponsePlan.new(
       city_state_zip: PLACEHOLDER,
-      contacts: contacts,
       image: PLACEHOLDER_IMAGE,
       license_number: PLACEHOLDER,
       license_state: PLACEHOLDER,

--- a/app/views/sections/_contacts.html.erb
+++ b/app/views/sections/_contacts.html.erb
@@ -7,11 +7,16 @@
   </div>
 
   <div class="section-body">
-    <% @plan.contacts.each do |contact| %>
+    <% @person.contacts.each do |contact| %>
       <div class="contact">
-        <span class="contact-name"><%= contact[:name] %></span> (<%= contact[:relationship] %>)<br/>
-        <%= contact[:phone] %><br/>
-        <span class="notes"><%= contact[:notes] %></span>
+        <div class="contact-name"><%= contact.name %></div>
+        <div class="contact-relationship">Relationship: <%= contact.relationship %></div>
+        <div class="contact-cell">Cell: <%= tel_to contact.cell %></div>
+
+        <div class="contact-notes">
+          <div class="contact-notes-label">Notes</div>
+          <%= contact.notes %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/db/migrate/20160421210227_create_contacts.rb
+++ b/db/migrate/20160421210227_create_contacts.rb
@@ -1,0 +1,13 @@
+class CreateContacts < ActiveRecord::Migration
+  def change
+    create_table :contacts do |t|
+      t.belongs_to :person, index: true, foreign_key: true
+      t.string :name
+      t.string :relationship
+      t.string :cell
+      t.string :notes
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160419221546) do
+ActiveRecord::Schema.define(version: 20160421210227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_trgm"
   enable_extension "fuzzystrmatch"
+
+  create_table "contacts", force: :cascade do |t|
+    t.integer  "person_id"
+    t.string   "name"
+    t.string   "relationship"
+    t.string   "cell"
+    t.string   "notes"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "contacts", ["person_id"], name: "index_contacts_on_person_id", using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false
@@ -61,5 +73,6 @@ ActiveRecord::Schema.define(version: 20160419221546) do
 
   add_index "response_strategies", ["person_id"], name: "index_response_strategies_on_person_id", using: :btree
 
+  add_foreign_key "contacts", "people"
   add_foreign_key "response_strategies", "people"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,12 @@
 FactoryGirl.define do
+  factory :contact do
+    person nil
+    name "MyString"
+    relationship "MyString"
+    cell "MyString"
+    notes "MyString"
+  end
+
   factory :response_strategy do
     priority 1
     title "Contact case worker"

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -44,4 +44,20 @@ feature "Officer views a response plan" do
     expect(page).to have_content(step_1.title)
     expect(page).to have_content(step_2.title)
   end
+
+  scenario "They see emergency contacts" do
+    person = create(:person)
+    contact = create(
+      :contact,
+      person: person,
+      name: "Jane Doe",
+      relationship: "Case Worker",
+      cell: "222-333-4444",
+      notes: "Only available from 9am - 5pm",
+    )
+
+    visit person_path(person)
+
+    expect(page).to have_content(contact.name)
+  end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Contact, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Closes #84
## Feature:

When I am interacting with a person in crisis,
I want to quickly get in touch with people who know the person
so they can help respond to the crisis.
## Implementation:
- Add a `Contact` model
- Associate the contact model with a `Person`
- Replace the UI placeholders with the contact information
## Small changes:

Add a `tel_to` helper in the `ApplicationHelper` module,
which takes a phone number and turns it into a clickable link.

See http://makandracards.com/makandra/29353-tel_to-rails-helper-for-linking-phone-numbers
