### PR TITLE
Make the site responsive to screen resolution

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -1,10 +1,10 @@
 .footer {
   background-color: $header-background-color;
-  bottom: 0;
   box-shadow: $shadow-level-4;
   color: $white-text;
   font-size: 1rem;
   position: absolute;
+  bottom: 0;
   width: 100%;
   padding: $small-spacing;
 }

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -1,9 +1,14 @@
 .left-column {
-  @include span-columns(4 of 12);
+  @include media($large-screen-up) {
+    @include span-columns(4 of 12);
+  }
 }
 
 .right-column {
-  @include span-columns(8 of 12);
+  @include media($large-screen-up) {
+    @include span-columns(8 of 12);
+  }
+
   @include omega;
   overflow: hidden;
 }

--- a/app/assets/stylesheets/_people.scss
+++ b/app/assets/stylesheets/_people.scss
@@ -21,7 +21,9 @@ section.images img {
 }
 
 .officer-safety {
-  @include span-columns(4 of 8);
+  @include media($medium-screen-up) {
+    @include span-columns(4 of 8);
+  }
 }
 
 .response-plan {

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -6,7 +6,9 @@
   }
 
   .fields {
-    @include span-columns(8 of 12);
+    @include media($medium-screen-up) {
+      @include span-columns(8 of 12);
+    }
   }
 
   label {
@@ -20,7 +22,9 @@
   }
 
   .actions {
-    @include span-columns(4 of 12);
+    @include media($medium-screen-up) {
+      @include span-columns(4 of 12);
+    }
   }
 
   input[type="submit"] {

--- a/app/assets/stylesheets/response_plan/_physical.scss
+++ b/app/assets/stylesheets/response_plan/_physical.scss
@@ -1,6 +1,8 @@
 .physical {
-  @include span-columns(4 of 8);
-  @include omega;
+  @include media($medium-screen-up) {
+    @include span-columns(4 of 8);
+    @include omega;
+  }
 
   .section-body span {
     display: block;


### PR DESCRIPTION
## Problem:

The site was using a hard-coded three-column layout,
regardless of the user's screen size.
At small screen sizes, the information got very compacted,
and the app became essentially unusable.
## Solution:

By default, display all information in a single-column layout.
Set breakpoints so that larger screen resolutions
can break the information into multiple columns.
