### PR TITLE
Stick the footer to the bottom of the page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,9 +19,20 @@
 
 @import "response_plan/*";
 
+html, body {
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+
+html {
+  height: 100%;
+}
+
 body {
   font-family: $base-font-family;
   font-size: 20px;
+  min-height: 100%;
   width: 100%;
   background-color: #f0f0f0;
 }
@@ -57,6 +68,6 @@ h1, h2, h3, h4, h5, h6 {
 
 .content {
   @include outer-container($page-width);
-  margin-top: $header-height + $base-spacing * 1.5;
+  padding-top: $header-height + $base-spacing * 1.5;
+  padding-bottom: 4rem;
 }
-


### PR DESCRIPTION
## Problem:

On pages without much content,
the footer was appearing immediately after the content
instead of sticking to the bottom.
## Solution:

Make the footer stick to the bottom.
See: http://cssreset.com/how-to-keep-footer-at-bottom-of-page-with-css/
