### PR TITLE
Place header and footer above other content

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -1,12 +1,13 @@
 .footer {
   background-color: $header-background-color;
+  bottom: 0;
   box-shadow: $shadow-level-4;
   color: $white-text;
   font-size: 1rem;
-  position: absolute;
-  bottom: 0;
-  width: 100%;
   padding: $small-spacing;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
 }
 
 .footer-content {

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -10,6 +10,7 @@
   text-transform: uppercase;
   top: 0;
   width: 100%;
+  z-index: 1;
 
   &:hover {
     color: $white-text;


### PR DESCRIPTION
Problem:

The eye and hair icons in the physical characteristics section
were showing on top of the header as the user scrolled down the page.

Solution:

Specify the header and footer z-index to ensure they stay on top.
