### PR TITLE
Make app runnable both in Docker and locally

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,12 @@
 # https://github.com/ddollar/forego
+#
+# Override any of these variables in `.env.local`
+# if the values are different on your machine
+
 ASSET_HOST=localhost:3000
 APPLICATION_HOST=localhost:3000
+DB_HOST=localhost
+DB_USER=postgres
 PORT=3000
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,14 @@ FROM ruby:latest
 
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
 
+# Set up tools needed for a bare-minimum debugging dev environment
+RUN apt-get install -y vim
+
 # for nokogiri
 RUN apt-get install -y libxml2-dev libxslt1-dev
 
-RUN apt-get install -y vim
+# Javascript runtime
+RUN apt-get install -y nodejs
 
 ENV PHANTOM_PACKAGE phantomjs-2.1.1-linux-x86_64
 ADD https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_PACKAGE.tar.bz2 .

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "rails", "~> 4.2.0"
 gem "recipient_interceptor"
 gem "sass-rails", "~> 5.0"
 gem "simple_form"
-gem "therubyracer", platforms: :ruby
 gem "title"
 gem "uglifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,6 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.13)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -217,7 +216,6 @@ GEM
     rake (11.1.2)
     recipient_interceptor (0.1.2)
       mail
-    ref (2.0.0)
     refills (0.1.0)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
@@ -263,9 +261,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
-      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -338,7 +333,6 @@ DEPENDENCIES
   shoulda-matchers
   simple_form
   simplecov
-  therubyracer
   timecop
   title
   uglifier

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ development: &default
   adapter: postgresql
   database: crisisresponse_development
   encoding: utf8
-  username: postgres
+  username: <%= ENV.fetch("DB_USER", "postgres") %>
   password:
   host: <%= ENV.fetch("DB_HOST") %>
   min_messages: warning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     command: ./bin/serve
     environment:
       DB_HOST: db
+      DB_USER: postgres
     ports:
       - "3000:3000"
     links:


### PR DESCRIPTION
## Problem:

Our application relied on libv8 as a javascript runtime in Docker
(as a dependency of the gem`therubyracer`),
but it wasn't readily installable on my local machine.
This means we needed to run all rake or rails commands
within Docker, which is a bit cumbersome for a dev workflow.
## Solution:
- Install nodejs as a javascript runtime in the Docker image,
  so we don't need to rely on libv8.
- Remove the dependency on `therubyracer`,
  and let developers choose their own javascript runtimes.
- Because we can now run the tests in multiple environments,
  the user can now specify which database to use
  through the `DB_HOST` and `DB_USER` environment variables.
## Notes:

On local machines, users can install any javascript runtime
that is supported by [ExecJS](https://github.com/sstephenson/execjs).
At this time, that includes:
- therubyracer - Google V8 embedded within Ruby
- therubyrhino - Mozilla Rhino embedded within JRuby
- Node.js
- Apple JavaScriptCore - Included with Mac OS X
- Microsoft Windows Script Host (JScript)
