### PR TITLE
Reduce the size of the Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+build
+log
+public/assets
+public/uploads
+public/system
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM ruby:latest
 
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
 
-# Set up tools needed for a bare-minimum debugging dev environment
-RUN apt-get install -y vim
-
 # for nokogiri
 RUN apt-get install -y libxml2-dev libxslt1-dev
 


### PR DESCRIPTION
## Problem:

We weren't ignoring any directories when we built our Docker image,
which means we packaged up our entire git history and logs
into the image.

Even worse, we were packaging up the `build` directory into the image.
Since we're storing the zipped Docker images there,
the Docker image size would approximately double every time we built it.
## Solution:

Ignore a bunch of files that we don't need in our Docker image,
and don't install vim unless we have a good need for it.
