### PR TITLE
Set up search as the homepage

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,6 @@ Rails.application.routes.draw do
 
   resources :people, only: [:index, :show]
   resources :feedbacks, only: [:new, :create]
+
+  root to: "people#index"
 end


### PR DESCRIPTION
## Problem:

Previously, visiting the site's URL gave a default Rails intro page.
Users needed to visit the `/people` route to get access to the app.
## Solution:

Change the root URL to point to the search page.
