### PR TITLE
Format search results as block elements with pics

### DIFF
--- a/app/assets/stylesheets/_people.scss
+++ b/app/assets/stylesheets/_people.scss
@@ -17,7 +17,7 @@ $radius: 6px;
 
 section.images img {
   width: 100%;
-  border: 1px solid $dark-gray;
+  border: $dark-border
 }
 
 .safety-warnings {

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -1,5 +1,6 @@
 .search {
   overflow: hidden;
+  margin-bottom: $base-spacing;
 
   h1 {
     margin-bottom: $base-spacing;
@@ -31,5 +32,78 @@
     @include span-columns(3 of 4);
     @include shift(1);
     padding: $base-spacing;
+  }
+}
+
+.search-results {
+  margin-top: $base-spacing;
+}
+
+.search-result {
+  @include span-columns(4 of 4);
+
+  img {
+    max-width: 40%;
+
+    @include media($medium-screen-up) {
+      max-width: none;
+    }
+  }
+
+  .search-result-labels {
+    width: 50%;
+    float: right;
+
+    @include media($medium-screen-up) {
+      width: auto;
+      float: none;
+    }
+  }
+
+  @include media($medium-screen-up) {
+    @include span-columns(4 of 8);
+
+    &:nth-child(2n) {
+      @include omega;
+    }
+  }
+
+  @include media($large-screen-up) {
+    @include span-columns(3 of 12);
+
+    &:nth-child(4n) {
+      @include omega;
+    }
+  }
+
+  margin-bottom: $base-spacing;
+
+  img {
+    border: $dark-border;
+    height: 6em;
+    margin: 0;
+
+    @include media($medium-screen-up) {
+      display: block;
+      height: 8em;
+      margin-bottom: $small-spacing;
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+
+  .search-result-name,
+  .search-result-dob {
+    color: $base-font-color;
+    display: block;
+
+    @include media($medium-screen-up) {
+      text-align: center;
+    }
+  }
+
+  .search-result-name {
+    @include heavy-font;
+    text-transform: uppercase;
   }
 }

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -48,6 +48,7 @@ $white-text: #fff;
 // Border
 $base-border-color: $light-gray;
 $base-border: 1px solid $base-border-color;
+$dark-border: 1px solid $dark-gray;
 
 // Shadows
 $shadow-level-1: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -35,6 +35,10 @@ class Person < ActiveRecord::Base
 
   mount_uploader :image, ImageUploader
 
+  def display_name
+    "#{last_name}, #{first_name}"
+  end
+
   def name=(value)
     (self.first_name, self.last_name) = value.split
   end

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -18,27 +18,21 @@
   </div>
 <% end %>
 
-<% if @people.any? %>
-  <table>
-    <thead>
-      <tr>
-        <td>First Name</td>
-        <td>Last Name</td>
-        <td>DOB</td>
-        <td>Actions</td>
-      </tr>
-    </thead>
-    <tbody>
-      <% @people.each do |person, event_count| %>
-        <tr>
-          <td><%= person.first_name.humanize %></td>
-          <td><%= person.last_name.humanize %></td>
-          <td><%= person.date_of_birth %></td>
-          <td><%= link_to("Show data", "/people/#{person.name.downcase}") %></td>
-        </tr>
+
+<h2>Results</h2>
+
+<div class="search-results">
+  <% if @people.any? %>
+    <% @people.each do |person| %>
+      <%= link_to person_path(person), class: "search-result" do %>
+        <%= image_tag person.image_url %>
+        <div class="search-result-labels">
+          <span class="search-result-name"><%= person.display_name %></span>
+          <span class="search-result-dob"><%= l person.date_of_birth %></span>
+        </div>
       <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <%= t("search.results.none") %>
-<% end %>
+    <% end %>
+  <% else %>
+    <%= t("search.results.none") %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   date:
     formats:
       default:
-        "%m/%d/%Y"
+        "%m-%d-%Y"
       with_weekday:
         "%a %m/%d/%y"
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -9,20 +9,20 @@ feature "Search", :js do
     visit people_path
 
     fill_form_and_submit(:person_search, name: "John")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, name: "Doe")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, name: "John Doe")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, name: "Doe John")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
   end
 
   scenario "Officer searches by a person's DOB" do
@@ -33,20 +33,20 @@ feature "Search", :js do
     visit people_path
 
     fill_form_and_submit(:person_search, "DOB" => "1/2/80")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, "DOB" => "1-2-1980")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, "DOB" => "1-2-80")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, "DOB" => "1980-1-2")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
   end
 
   scenario "Officer searches by a person's name and DOB" do
@@ -58,8 +58,8 @@ feature "Search", :js do
 
     fill_form_and_submit(:person_search, name: "Doe John", "DOB" => "1/2/80")
 
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
   end
 
   scenario "Officer searches by a name with no match" do
@@ -71,8 +71,8 @@ feature "Search", :js do
     fill_form_and_submit(:person_search, name: "Mary")
 
     expect(page).to have_content(t("search.results.none"))
-    expect(page).not_to have_content(name)
-    expect(page).not_to have_content(format_date(dob))
+    expect(page).not_to have_content(person.display_name.upcase)
+    expect(page).not_to have_content(l(dob))
   end
 
   scenario "Officer searches by a DOB with no match" do
@@ -84,8 +84,8 @@ feature "Search", :js do
 
     fill_form_and_submit(:person_search, "DOB" => "2/3/86")
     expect(page).to have_content(t("search.results.none"))
-    expect(page).not_to have_content(name)
-    expect(page).not_to have_content(format_date(dob))
+    expect(page).not_to have_content(person.display_name.upcase)
+    expect(page).not_to have_content(l(dob))
   end
 
   scenario "Officer searches by a name that's slightly off" do
@@ -96,20 +96,20 @@ feature "Search", :js do
     visit people_path
 
     fill_form_and_submit(:person_search, name: "Jon")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, name: "Doh")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, name: "Jon Doh")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, name: "Doh Jon")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
   end
 
   scenario "Officer searches by a DOB that's slightly off" do
@@ -120,16 +120,16 @@ feature "Search", :js do
     visit people_path
 
     fill_form_and_submit(:person_search, "DOB" => "1/2/81")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, "DOB" => "1/2/79")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
 
     fill_form_and_submit(:person_search, "DOB" => "1/2/80")
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
   end
 
   scenario "Officer searches by a name and DOB that are slightly off" do
@@ -141,8 +141,8 @@ feature "Search", :js do
 
     fill_form_and_submit(:person_search, name: "Jon Doh", "DOB" => "1/2/81")
 
-    expect(page).to have_content(name)
-    expect(page).to have_content(format_date(dob))
+    expect(page).to have_content(person.display_name.upcase)
+    expect(page).to have_content(l(dob))
   end
 
   scenario "Officer searches by a name that matches, and DOB that doesn't" do
@@ -155,8 +155,8 @@ feature "Search", :js do
     fill_form_and_submit(:person_search, name: "Jon Doh", "DOB" => "1/2/85")
 
     expect(page).to have_content(t("search.results.none"))
-    expect(page).not_to have_content(name)
-    expect(page).not_to have_content(format_date(dob))
+    expect(page).not_to have_content(person.display_name.upcase)
+    expect(page).not_to have_content(l(dob))
   end
 
   scenario "Officer searches by a DOB that matches, and name that doesn't" do
@@ -169,11 +169,7 @@ feature "Search", :js do
     fill_form_and_submit(:person_search, name: "Mary", "DOB" => "1/2/80")
 
     expect(page).to have_content(t("search.results.none"))
-    expect(page).not_to have_content(name)
-    expect(page).not_to have_content(format_date(dob))
-  end
-
-  def format_date(date)
-    date.strftime("%Y-%m-%d")
+    expect(page).not_to have_content(person.display_name.upcase)
+    expect(page).not_to have_content(l(dob))
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Person, type: :model do
     it { should have_many :safety_warnings }
   end
 
+  describe "#display_name" do
+    it "displays last name, first name" do
+      person = build(:person, first_name: "John", last_name: "Doe")
+
+      expect(person.display_name).to eq("Doe, John")
+    end
+  end
+
   describe "#shorthand_description" do
     it "starts with a letter representing race" do
       expect(shorthand_for(race: "AFRICAN AMERICAN/BLACK")).to start_with("B")


### PR DESCRIPTION
## Problem:

Search results were displayed in a table,
which isn't very scannable or actionable for officers.
## Solution:

Display search results as an image with the person's name and DOB below.
## Preview

![crisis_response](https://cloud.githubusercontent.com/assets/829576/14871952/2ef475ea-0c9c-11e6-8d3a-e385a0a70bc2.png)

![crisis_response](https://cloud.githubusercontent.com/assets/829576/14871969/6910c9ae-0c9c-11e6-8137-89c1ab4917db.png)
