### PR TITLE
Remove peoples' names from the URL

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -8,12 +8,6 @@ module Admin
     #   @resources = Person.all.paginate(10, params[:page])
     # end
 
-    # Define a custom finder by overriding the `find_resource` method:
-    def find_resource(param)
-      first_name, last_name = params[:id].titleize.split
-      @person = Person.find_by!(first_name: first_name, last_name: last_name)
-    end
-
     # See https://administrate-docs.herokuapp.com/customizing_controller_actions
     # for more information
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -9,15 +9,7 @@ class PeopleController < ApplicationController
   end
 
   def show
-    first_name, last_name = params[:id].titleize.split
-    @person = Person.find_by(first_name: first_name, last_name: last_name)
-    @events = events_for(@person)
-
-    @plan = find_most_recent_plan_for_person(@person)
-
-    if @events.none?
-      redirect_to :people, alert: "Could not find any records for #{@person.name}"
-    end
+    @person = Person.find(params[:id])
   end
 
   private
@@ -25,10 +17,6 @@ class PeopleController < ApplicationController
   def events_for(person)
     rms = RMSAdapter.new
     rms.events_for(person)
-  end
-
-  def find_most_recent_plan_for_person(person)
-    ResponsePlanBuilder.build({})
   end
 
   def search_params

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -63,10 +63,6 @@ class Person < ActiveRecord::Base
     ].compact.join(" – ")
   end
 
-  def to_param
-    name
-  end
-
   private
 
   def height_in_feet_and_inches


### PR DESCRIPTION
## Problem:

We're currently embedding peoples' names in the URL,
which has the potential to cause several problems:
- The fact that a person has a response plan in our system
  may count as personal health information.
  If so, then simply sharing a link to our app
  would mean sharing HIPAA-protected information.
- The URLs have spaces in them.
  That's just flat-out bad practice,
  and will probably break a fair amount of functionality,
  such as linking from the CAD hazard entries.
- Names are not unique identifiers,
  so using them in the URL may cause collisions
  (multiple response plans using the same URL).
## Solution:

Reset to the standard Rails default
of using database IDs as the URL parameter.
## Small Changes:

Remove unused methods from the response plan controller.
