### PR TITLE
Display author & approver in response plan

### DIFF
--- a/app/assets/stylesheets/response_plan/_about.scss
+++ b/app/assets/stylesheets/response_plan/_about.scss
@@ -1,0 +1,23 @@
+.about {
+  font-size: 0.8rem;
+
+  @include media($medium-screen-up) {
+    @include span-columns(4 of 8);
+  }
+
+  .about-author {
+    margin-bottom: $base-spacing;
+    overflow: hidden;
+  }
+
+  .author-label,
+  .approver-label {
+    @include heavy-font;
+    @include span-columns(1.5 of 4);
+  }
+
+  .author-info,
+  .approver-info {
+    @include span-columns(2.5 of 4);
+  }
+}

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -10,6 +10,7 @@ class PeopleController < ApplicationController
 
   def show
     @person = Person.find(params[:id])
+    ensure_person_is_approved(@person)
   end
 
   private
@@ -24,6 +25,12 @@ class PeopleController < ApplicationController
       params.require(:person_search).permit(:name, :date_of_birth)
     else
       {}
+    end
+  end
+
+  def ensure_person_is_approved(person)
+    unless person.approved?
+      raise ActiveRecord::RecordNotFound
     end
   end
 end

--- a/app/models/officer.rb
+++ b/app/models/officer.rb
@@ -1,0 +1,11 @@
+class Officer < ActiveRecord::Base
+  has_many :authored_response_plans,
+    class_name: "Person",
+    foreign_key: :author_id,
+    dependent: :destroy
+
+  has_many :approved_response_plans,
+    class_name: "Person",
+    foreign_key: :approver_id,
+    dependent: :destroy
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,6 +5,9 @@ class Person < ActiveRecord::Base
   has_many :response_strategies, -> { order(:priority) }, dependent: :destroy
   has_many :safety_warnings, dependent: :destroy
 
+  belongs_to :author, class_name: "Officer"
+  belongs_to :approver, class_name: "Officer"
+
   RACE_CODES = {
     "AFRICAN AMERICAN/BLACK" => "B",
     "AMERICAN INDIAN/ALASKAN NATIVE" => "I",
@@ -20,6 +23,9 @@ class Person < ActiveRecord::Base
 
   validates :sex, inclusion: SEX_CODES.keys, allow_nil: true
   validates :race, inclusion: RACE_CODES.keys, allow_nil: true
+  validate :approver_is_not_author
+  validate :approved_at_is_present_if_approver_exists
+  validate :approver_is_present_if_approved_at_exists
 
   pg_search_scope(
     :search,
@@ -34,6 +40,20 @@ class Person < ActiveRecord::Base
   )
 
   mount_uploader :image, ImageUploader
+
+  def approved?
+    approved_at.present? && approver.present?
+  end
+
+  def approver=(value)
+    super(value)
+
+    if(value.present?)
+      self.approved_at = Time.current
+    else
+      self.approved_at = nil
+    end
+  end
 
   def display_name
     "#{last_name}, #{first_name}"
@@ -64,6 +84,30 @@ class Person < ActiveRecord::Base
   end
 
   private
+
+  def approver_is_not_author
+    if approver_id == author_id
+      errors.add(:approver, "can not be the person who authored the plan")
+    end
+  end
+
+  def approved_at_is_present_if_approver_exists
+    if approver.present? && approved_at.nil?
+      errors.add(
+        :approved_at,
+        "must be set in order to be approved",
+      )
+    end
+  end
+
+  def approver_is_present_if_approved_at_exists
+    if approved_at.present? && approver.nil?
+      errors.add(
+        :approved_at,
+        "cannot be set without an approver",
+      )
+    end
+  end
 
   def height_in_feet_and_inches
     if height_in_inches

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -13,5 +13,6 @@
     <%= render "sections/physical" %>
     <%= render "sections/response_plan" %>
     <%= render "sections/contacts" %>
+    <%= render "sections/about" %>
   </div>
 </div>

--- a/app/views/sections/_about.html.erb
+++ b/app/views/sections/_about.html.erb
@@ -1,0 +1,26 @@
+<section class="about">
+  <div class="section-header">
+    <%= image_tag("section-icons/response-plan.svg", class: "section-icon") %>
+    <div class="section-header-text">
+      <h2 class="section-title">About the Plan</h2>
+    </div>
+  </div>
+
+  <div class="section-body">
+    <div class="about-author">
+      <div class="author-label">Prepared By</div>
+      <div class="author-info">
+        <div><%= @person.author.name %></div>
+        <div><%= @person.author.unit %></div>
+        <div><%= @person.author.phone %></div>
+      </div>
+    </div>
+
+    <div class="about-approver">
+      <div class="approver-label">Approved By</div>
+      <div class="approver-info">
+        <div><%= @person.approver.name %></div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/db/migrate/20160502173849_create_officers.rb
+++ b/db/migrate/20160502173849_create_officers.rb
@@ -1,0 +1,42 @@
+class Officer < ActiveRecord::Base; end
+class Person < ActiveRecord::Base; end
+
+class CreateOfficers < ActiveRecord::Migration
+  def up
+    create_table :officers do |t|
+      t.string :name, null: false
+      t.string :unit, null: false
+      t.string :title
+      t.string :phone
+
+      t.timestamps null: false
+    end
+
+    officer = Officer.create(
+      name: "TEMPORARY - REPLACE ME",
+      unit: "TEMPORARY - REPLACE ME",
+    )
+
+    add_column :people, :author_id, :integer
+    add_column :people, :approver_id, :integer
+    add_column :people, :approved_at, :datetime
+
+    add_index :people, :approver_id
+    add_index :people, :author_id
+
+    Person.update_all(author_id: officer.id)
+
+    change_column_null :people, :author_id, false
+  end
+
+  def down
+    remove_index :people, :approver_id
+    remove_index :people, :author_id
+
+    remove_column :people, :author_id
+    remove_column :people, :approver_id
+    remove_column :people, :approved_at
+
+    drop_table :officers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160427043932) do
+ActiveRecord::Schema.define(version: 20160502173849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,15 @@ ActiveRecord::Schema.define(version: 20160427043932) do
     t.datetime "updated_at",  null: false
   end
 
+  create_table "officers", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.string   "unit",       null: false
+    t.string   "title"
+    t.string   "phone"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "people", force: :cascade do |t|
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
@@ -67,7 +76,13 @@ ActiveRecord::Schema.define(version: 20160427043932) do
     t.date     "date_of_birth"
     t.string   "scars_and_marks"
     t.string   "image"
+    t.integer  "author_id",        null: false
+    t.integer  "approver_id"
+    t.datetime "approved_at"
   end
+
+  add_index "people", ["approver_id"], name: "index_people_on_approver_id", using: :btree
+  add_index "people", ["author_id"], name: "index_people_on_author_id", using: :btree
 
   create_table "response_strategies", force: :cascade do |t|
     t.integer  "priority"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,8 +4,23 @@
 # (or created alongside the db with db:setup).
 
 Person.destroy_all
+Officer.destroy_all
 
-person = Person.create(
+author = Officer.create!(
+  name: "Dan Nelson",
+  title: "Sgt",
+  unit: "Crisis Response Unit",
+  phone: "222-333-4444",
+)
+
+approver = Officer.create!(
+  name: "Eric Pisconski",
+  title: "Sgt",
+  unit: "Crisis Response Unit",
+  phone: "222-333-4455",
+)
+
+person = Person.create!(
   name: "John Doe",
   image: File.open(Rails.root + "spec/fixtures/image.jpg"),
   sex: "Male",
@@ -16,23 +31,25 @@ person = Person.create(
   eye_color: "Brown",
   date_of_birth: Date.new(1980, 01, 02),
   scars_and_marks: "Skull tattoo on neck",
+  author: author,
+  approver: approver,
 )
 
-ResponseStrategy.create(
+ResponseStrategy.create!(
   person: person,
   title: "Call case manager",
   description: "The case manager usually can calm John down over the phone",
   priority: 1,
 )
 
-ResponseStrategy.create(
+ResponseStrategy.create!(
   person: person,
   title: "Send to DESC",
   description: "John knows the staff at DESC, and they may be able to help",
   priority: 2,
 )
 
-Contact.create(
+Contact.create!(
   person: person,
   name: "Jane Doe",
   relationship: "Sister",
@@ -40,7 +57,7 @@ Contact.create(
   notes: "Lives in Bellevue",
 )
 
-Contact.create(
+Contact.create!(
   person: person,
   name: "Mark Johnson",
   relationship: "Case worker",
@@ -48,12 +65,12 @@ Contact.create(
   notes: "Available from 9am - 5pm",
 )
 
-SafetyWarning.create(
+SafetyWarning.create!(
   person: person,
   description: "owns a gun",
 )
 
-SafetyWarning.create(
+SafetyWarning.create!(
   person: person,
   description: "has previously possessed needles",
 )

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -5,5 +5,13 @@ RSpec.describe PeopleController, type: :controller do
   end
 
   describe "GET #show" do
+    context "when the plan has not been approved" do
+      scenario "they do not see the response plan" do
+        person = create(:person, approver: nil)
+
+        expect { get :show, id: 20 }.
+          to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -12,14 +12,16 @@ FactoryGirl.define do
     description "MyText"
   end
 
-  factory :response_strategy do
-    priority 1
-    title "Contact case worker"
-    description "Case worker is Sam Smith at DESC"
-    person
+  factory :officer, aliases: [:author, :approver] do
+    title "Officer"
+    name "Johnson"
+    unit "Crisis Response Unit"
+    phone "222-333-4444"
   end
 
   factory :person do
+    author
+    approver
     name "John Doe"
     sex "Male"
     race "AFRICAN AMERICAN/BLACK"
@@ -28,6 +30,13 @@ FactoryGirl.define do
     hair_color "black"
     eye_color "blue"
     date_of_birth { 25.years.ago }
+  end
+
+  factory :response_strategy do
+    priority 1
+    title "Contact case worker"
+    description "Case worker is Sam Smith at DESC"
+    person
   end
 
   factory :safety_warning do

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -64,6 +64,24 @@ feature "Officer views a response plan" do
     expect(page).to have_content(contact.notes)
   end
 
+  scenario "They see the preparing officer" do
+    officer = create(:officer, name: "Jacques Clouseau")
+    person = create(:person, author: officer)
+
+    visit person_path(person)
+
+    expect(page).to have_content("Prepared By Jacques Clouseau")
+  end
+
+  scenario "They see the approving officer" do
+    officer = create(:officer, name: "Jacques Clouseau")
+    person = create(:person, approver: officer)
+
+    visit person_path(person)
+
+    expect(page).to have_content("Approved By Jacques Clouseau")
+  end
+
   context "when there are no safety warnings" do
     scenario "they see 'No history of violence'" do
       person = create(:person)

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe Contact, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/officer_spec.rb
+++ b/spec/models/officer_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Officer, type: :model do
+  describe "associations" do
+    it { should have_many(:authored_response_plans).dependent(:destroy) }
+    it { should have_many(:approved_response_plans).dependent(:destroy) }
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -17,12 +17,102 @@ RSpec.describe Person, type: :model do
     it { should_not allow_value("BLACK").for(:race) }
     it { should_not allow_value("W").for(:race) }
     it { should_not allow_value("White").for(:race) }
+
+    it "does not allow the same officer to both author and approve" do
+      officer = build(:officer)
+      person = build(:person, author: officer, approver: officer)
+
+      expect(person).not_to be_valid
+      expect(person.errors[:approver]).
+        to include("can not be the person who authored the plan")
+    end
+
+    it "does not allow approval without a timestamp" do
+      officer = build(:officer)
+      person = build(:person, approver: officer)
+      person.approved_at = nil
+
+      expect(person).not_to be_valid
+      expect(person.errors[:approved_at]).
+        to include("must be set in order to be approved")
+    end
+
+    it "does not allow approval without an approver" do
+      person = build(:person, approved_at: Time.current, approver: nil)
+
+      expect(person).not_to be_valid
+      expect(person.errors[:approved_at]).
+        to include("cannot be set without an approver")
+    end
   end
 
   describe "associations" do
     it { should have_many(:safety_warnings).dependent(:destroy) }
     it { should have_many(:contacts).dependent(:destroy) }
     it { should have_many(:response_strategies).dependent(:destroy) }
+    it { should belong_to(:author) }
+    it { should belong_to(:approver) }
+  end
+
+  describe "#approved?" do
+    it "returns true if both `approved_at` and `approver` are non-nil" do
+      officer = build(:officer)
+      person = build_stubbed(
+        :person,
+        approved_at: Time.current,
+        approver: officer,
+      )
+
+      expect(person).to be_approved
+    end
+
+    it "returns false if `approved_at` is nil" do
+      officer = build(:officer)
+      person = build_stubbed(
+        :person,
+        approved_at: nil,
+        approver: officer,
+      )
+
+      expect(person).not_to be_approved
+    end
+
+    it "returns false if `approver` is nil" do
+      officer = build(:officer)
+      person = build_stubbed(
+        :person,
+        approved_at: Time.current,
+        approver: nil,
+      )
+
+      expect(person).not_to be_approved
+    end
+  end
+
+  describe "#approver=" do
+    it "updates the `approved_at` timestamp" do
+      officer = build(:officer)
+      person = build_stubbed(:person, approved_at: nil, approver: nil)
+
+      Timecop.freeze do
+        person.approver = officer
+
+        expect(person.approved_at).to eq(Time.current)
+      end
+    end
+
+    it "sets `approved_at` to nil when approver is nil" do
+      officer = build(:officer)
+      person = build_stubbed(
+        :person,
+        approved_at: Time.current,
+        approver: officer,
+      )
+
+      person.approver = nil
+
+      expect(person.approved_at).to eq(nil)
+    end
   end
 
   describe "#display_name" do

--- a/spec/models/response_strategy_spec.rb
+++ b/spec/models/response_strategy_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe ResponseStrategy, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
## Feature:

When I'm interacting with a person in crisis
And I need more information about the person
I want to contact the officer who created their response plan
So I can talk to them about the person.
## Implementation:

Create an `Officer` model
with a name, title, unit, and phone number.

Associate each response plan with two officers –
the plan's officer, and the officer who approved the plan.

Plans are not visible to patrol officers until they have been approved.

A plan's author can not approve the response plan

Add a box to the bottom of the response plan page,
with the author's name, unit, and phone number.
Also display the name of the officer who approved the response plan.
