### PR TITLE
Add background information to response plans

### DIFF
--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -12,6 +12,7 @@
     <%= render "sections/safety_warnings" %>
     <%= render "sections/physical" %>
     <%= render "sections/response_plan" %>
+    <%= render "sections/background_info" %>
     <%= render "sections/contacts" %>
     <%= render "sections/about" %>
   </div>

--- a/app/views/sections/_background_info.html.erb
+++ b/app/views/sections/_background_info.html.erb
@@ -1,0 +1,12 @@
+<section class="background-info">
+  <div class="section-header">
+    <%= image_tag("section-icons/response-plan.svg", class: "section-icon") %>
+    <div class="section-header-text">
+      <h2 class="section-title">Background Information</h2>
+    </div>
+  </div>
+
+  <div class="section-body">
+    <%= @person.background_info %>
+  </div>
+</section>

--- a/db/migrate/20160503173959_add_background_info_to_people.rb
+++ b/db/migrate/20160503173959_add_background_info_to_people.rb
@@ -1,0 +1,5 @@
+class AddBackgroundInfoToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :background_info, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160502173849) do
+ActiveRecord::Schema.define(version: 20160503173959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 20160502173849) do
     t.integer  "author_id",        null: false
     t.integer  "approver_id"
     t.datetime "approved_at"
+    t.text     "background_info"
   end
 
   add_index "people", ["approver_id"], name: "index_people_on_approver_id", using: :btree

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -45,6 +45,15 @@ feature "Officer views a response plan" do
     expect(page).to have_content(step_2.title)
   end
 
+  scenario "They see background information" do
+    background_text = "This is the person's background info"
+    person = create(:person, background_info: background_text)
+
+    visit person_path(person)
+
+    expect(page).to have_content(background_text)
+  end
+
   scenario "They see emergency contacts" do
     person = create(:person)
     contact = create(


### PR DESCRIPTION
## Problem:

The "Response Plan" section doesn't have enough space or flexibility
for officers to enter all the information about a person.
Some information is useful, but is not directly related
to how officers should respond to the person.
## Solution:

Create a "Background Information" section,
where the CRT officers can enter free-form information about a person
that is not related to their response plans.
