### PR TITLE
Make sure hamburger menu displays well on ie11

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -22,4 +22,10 @@
     margin: auto;
     width: $page-width;
   }
+
+  .header-icon {
+    height: $header-height / 2;
+    width: $header-height / 2;
+    margin-top: $header-height / 4;
+  }
 }

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -2,6 +2,6 @@
   <div class="header-content">
     <span class="header-title"><%= content_for(:header) %></span>
 
-    <%= image_tag "hamburger_menu.svg", class: "menu-icon" %>
+    <%= image_tag "hamburger_menu.svg", class: "header-icon" %>
   </div>
 <% end %>


### PR DESCRIPTION
Problem:

The car MDTs run IE11,
which doesn't display the hamburger menu correctly.

Solution:

Set an explicit height and width for the hamburger menu icon.
