### PR TITLE
Make the seeds file work when models aren't loaded

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,8 @@ approver = Officer.create!(
 )
 
 response_plan = ResponsePlan.create!(
-  name: "John Doe",
+  first_name: "John",
+  last_name: "Doe",
   sex: "Male",
   race: "AFRICAN AMERICAN/BLACK",
   height_in_inches: 70,
@@ -30,8 +31,8 @@ response_plan = ResponsePlan.create!(
   eye_color: "Brown",
   date_of_birth: Date.new(1980, 01, 02),
   scars_and_marks: "Skull tattoo on neck",
-  author: author,
-  approver: approver,
+  author_id: author.id,
+  approver_id: approver.id,
 )
 
 ResponseStrategy.create!(


### PR DESCRIPTION
Problem:

`rake db:seed` was failing on heroku, CentOS, and in our Docker images.

It gave errors including:

```
ActiveRecord::UnknownAttributeError: unknown attribute 'name' for ResponsePlan.
ActiveRecord::UnknownAttributeError: unknown attribute 'author' for ResponsePlan.
```

Solution:

Only seed based on direct database columns,
not custom methods or ActiveRecord relationship helpers
