### PR TITLE
Fix db seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,6 +33,7 @@ response_plan = ResponsePlan.create!(
   scars_and_marks: "Skull tattoo on neck",
   author_id: author.id,
   approver_id: approver.id,
+  approved_at: Time.current,
 )
 
 ResponseStrategy.create!(


### PR DESCRIPTION
Problem:

We were setting `approver` but not `approved_at`.
When the Rails model is not loaded correctly,
This causes a validation error

Solution:

Set both values explicitly
