### PR TITLE
Restrict access to officers signed in through LDAP

### DIFF
--- a/.env
+++ b/.env
@@ -11,6 +11,9 @@ PORT=3000
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret
 EXECJS_RUNTIME=Node
+LDAP_HOST=ldap.example.com
+LDAP_PORT=389
+LDAP_NAMESPACE="cn=Users,dc=Domain,dc=Domain"
 SMTP_ADDRESS=smtp.example.com
 SMTP_DOMAIN=example.com
 SMTP_PASSWORD=password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+* Officers can sign in with their existing SPD username and password
+
 No changes yet

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "flutie"
 gem "high_voltage"
 gem "jquery-rails"
 gem "neat", "~> 1.7.0"
+gem "net-ldap"
 gem "newrelic_rpm", ">= 3.9.8"
 gem "normalize-rails", "~> 3.0.0"
 gem "pg"
@@ -43,10 +44,11 @@ group :development, :test do
 end
 
 group :test do
-  gem "poltergeist"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"
+  gem "poltergeist"
+  gem "rack_session_access"
   gem "shoulda-matchers"
   gem "simplecov", require: false
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
+    net-ldap (0.11)
     newrelic_rpm (3.14.2.312)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -162,6 +163,9 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.3.2)
+    rack_session_access (0.1.1)
+      builder (>= 2.0.0)
+      rack (>= 1.0.0)
     rails (4.2.6)
       actionmailer (= 4.2.6)
       actionpack (= 4.2.6)
@@ -282,6 +286,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   neat (~> 1.7.0)
+  net-ldap
   newrelic_rpm (>= 3.9.8)
   normalize-rails (~> 3.0.0)
   pg
@@ -293,6 +298,7 @@ DEPENDENCIES
   quiet_assets
   rack-canonical-host
   rack-timeout
+  rack_session_access
   rails (~> 4.2.0)
   recipient_interceptor
   refills

--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -14,6 +14,7 @@
 @import "footer";
 @import "search";
 @import "section";
+@import "sign_in";
 @import "response_plans";
 @import "feedbacks";
 

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -42,13 +42,16 @@
     position: relative;
   }
 
+  a {
+    margin-right: 1.5em;
+    vertical-align: top;
+    color: $change-theme-button-color;
+  }
+
   .change-theme {
     background-color: $change-theme-button-background-color;
     border-radius: 3px;
-    color: $change-theme-button-color;
-    margin-right: 1.5em;
     padding: $small-spacing;
-    vertical-align: top;
     border: 1px solid $change-theme-button-color;
   }
 }

--- a/app/assets/stylesheets/_sign_in.scss
+++ b/app/assets/stylesheets/_sign_in.scss
@@ -1,0 +1,11 @@
+.sign_in,
+.new_password {
+  @include media($medium-screen-up) {
+    @include span-columns(6 of 12);
+    @include shift(3);
+  }
+
+  .form-actions {
+    margin-bottom: $base-spacing;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,22 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  helper_method :theme, :officer_signed_in?
+
+  def authenticate_officer!
+    unless officer_signed_in?
+      redirect_to(
+        new_authentication_path,
+        alert: t("authentication.unauthenticated"),
+      )
+    end
+  end
+
+  def officer_signed_in?
+    session[:officer_id].present?
+  end
+
   def theme
     session[:theme] || :day
   end
-
-  helper_method :theme
 end

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -1,0 +1,37 @@
+class AuthenticationsController < ApplicationController
+  def new
+    render locals: { sign_in: Authentication.new }
+  end
+
+  def create
+    authentication = Authentication.new(authentication_params)
+
+    if authentication.attempt_sign_on
+      officer = Officer.find_or_create_by(authentication.officer_information)
+      session[:officer_id] = officer.id
+      redirect_to(
+        response_plans_path,
+        notice: t("authentication.sign_in.success", name: officer.name),
+      )
+    else
+      redirect_to(
+        new_authentication_path,
+        alert: t("authentication.sign_in.failure"),
+      )
+    end
+  end
+
+  def destroy
+    session[:officer_id] = nil
+    redirect_to(
+      new_authentication_path,
+      notice: t("authentication.sign_out.success"),
+    )
+  end
+
+  private
+
+  def authentication_params
+    params.require(:authentication).permit(:username, :password)
+  end
+end

--- a/app/controllers/response_plans_controller.rb
+++ b/app/controllers/response_plans_controller.rb
@@ -3,6 +3,8 @@ require "net/http"
 require "rms_adapter"
 
 class ResponsePlansController < ApplicationController
+  before_action :authenticate_officer!
+
   def index
     @search = ResponsePlanSearch.new(search_params)
     @response_plans = @search.close_matches

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,37 @@
+class Authentication
+  include ActiveModel::Model
+
+  attr_accessor :username, :password
+
+  def attempt_sign_on
+    ldap_object.bind
+  end
+
+  def officer_information
+    object = ldap_object.search(base: ldap_user_path).first
+
+    {
+      name: "#{object[:givenname].first} #{object[:sn].first}",
+      username: object[:cn].first,
+    }
+  end
+
+  private
+
+  def ldap_object
+    @_ldap_object ||= Net::LDAP.new(
+      host: ENV.fetch("LDAP_HOST"),
+      port: ENV.fetch("LDAP_PORT"),
+      auth: {
+        method: :simple,
+        username: ldap_user_path,
+        password: password,
+      },
+    )
+  end
+
+  def ldap_user_path
+    namespace = ENV.fetch('LDAP_NAMESPACE')
+    "cn=#{username},#{namespace}"
+  end
+end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -5,6 +5,14 @@
     </div>
 
     <div class="header-actions">
+      <% if officer_signed_in? %>
+        <%= link_to(
+          t("authentication.sign_out.link"),
+          authentication_path,
+          method: :delete,
+        ) %>
+      <% end %>
+
       <%= link_to(
         "Night/Day",
         preferences_path(theme: :toggle),

--- a/app/views/authentications/new.html.erb
+++ b/app/views/authentications/new.html.erb
@@ -1,0 +1,20 @@
+<section class="sign_in">
+  <div class="section-header">
+    <div class="section-header-text">
+      <h2>Log in</h2>
+    </div>
+  </div>
+
+  <div class="section-body">
+    <%= simple_form_for(sign_in, url: authentication_path) do |f| %>
+      <div class="form-inputs">
+        <%= f.input :username, required: false, autofocus: true %>
+        <%= f.input :password, required: false %>
+      </div>
+
+      <div class="form-actions">
+        <%= f.button :submit, t("authentication.sign_in.link") %>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,4 +14,5 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: "www.example.com" }
   config.active_job.queue_adapter = :inline
+  config.middleware.use RackSessionAccess::Middleware
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,16 @@ en:
     form:
       label: Search by name, DOB, or physical description
 
+  authentication:
+    unauthenticated: Please sign in to continue.
+    sign_in:
+      link: Sign in
+      success: Signed in as %{name}
+      failure: Your username or password was incorrect. Please try again.
+    sign_out:
+      link: Sign out
+      success: Successfully signed out.
+
   time:
     formats:
       default:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
-  resources :response_plans, only: [:index, :show]
+  resource :authentication, only: [:new, :create, :destroy]
+
   resources :feedbacks, only: [:new, :create]
   resources :preferences, only: :create
+  resources :response_plans, only: [:index, :show]
 
   root to: "response_plans#index"
 end

--- a/db/migrate/20160519200159_add_username_to_officers.rb
+++ b/db/migrate/20160519200159_add_username_to_officers.rb
@@ -1,0 +1,6 @@
+class AddUsernameToOfficers < ActiveRecord::Migration
+  def change
+    add_column :officers, :username, :string
+    add_index :officers, :username, unique: true
+  end
+end

--- a/db/migrate/20160519212806_allow_officers_with_null_unit.rb
+++ b/db/migrate/20160519212806_allow_officers_with_null_unit.rb
@@ -1,0 +1,9 @@
+class AllowOfficersWithNullUnit < ActiveRecord::Migration
+  def up
+    change_column_null :officers, :unit, true
+  end
+
+  def down
+    change_column_null :officers, :unit, false, "TEMPORARY - REPLACE ME"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160503173959) do
+ActiveRecord::Schema.define(version: 20160519212806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,12 +55,15 @@ ActiveRecord::Schema.define(version: 20160503173959) do
 
   create_table "officers", force: :cascade do |t|
     t.string   "name",       null: false
-    t.string   "unit",       null: false
+    t.string   "unit"
     t.string   "title"
     t.string   "phone"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "username"
   end
+
+  add_index "officers", ["username"], name: "index_officers_on_username", unique: true, using: :btree
 
   create_table "response_plans", force: :cascade do |t|
     t.datetime "created_at",       null: false

--- a/spec/controllers/authentications_controller_spec.rb
+++ b/spec/controllers/authentications_controller_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe AuthenticationsController do
+  context "when the officer does not exist in our system" do
+    it "creates an officer" do
+      username = "foobar"
+      FakeAuthentication.new.stub_success
+
+      expect do
+        post :create, session_params(username: username)
+      end.to change(Officer, :count).by(1)
+    end
+
+    it "sets the session id to the new officer's id" do
+      username = "foobar"
+      FakeAuthentication.new(username: username).stub_success
+
+      post :create, session_params(username: username)
+
+      officer = Officer.find_by(username: username)
+      expect(session[:officer_id]).to eq(officer.id)
+    end
+  end
+
+  context "when the officer exists in our system" do
+    it "does not create an officer" do
+      name = "Foo Bar"
+      username = "foobar"
+      FakeAuthentication.new(name: name, username: username).stub_success
+      create(:officer, name: name, username: username)
+
+      expect do
+        post :create, session_params(username: username)
+      end.not_to change(Officer, :count)
+    end
+
+    it "sets the session id to the existing officer's id" do
+      name = "Foo Bar"
+      username = "foobar"
+      officer = create(:officer, name: name, username: username)
+      FakeAuthentication.new(name: name, username: username).stub_success
+
+      post :create, session_params(username: username)
+
+      expect(session[:officer_id]).to eq(officer.id)
+    end
+  end
+
+  context "when the authentication fails" do
+    it "does not create an officer" do
+      FakeAuthentication.new.stub_failure
+
+      expect do
+        post :create, session_params
+      end.not_to change(Officer, :count)
+    end
+  end
+
+  def session_params(username: "example")
+    { authentication: { username: username, password: "password" } }
+  end
+end

--- a/spec/controllers/response_plans_controller_spec.rb
+++ b/spec/controllers/response_plans_controller_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe ResponsePlansController, type: :controller do
   describe "GET #show" do
     context "when the plan has not been approved" do
       scenario "they do not see the response plan" do
+        officer = create(:officer)
         response_plan = create(:response_plan, approver: nil)
 
-        expect { get :show, id: 20 }.
+        expect { get :show, { id: 20 }, { officer_id: officer.id } }.
           to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/features/night_mode_spec.rb
+++ b/spec/features/night_mode_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
-feature "Night mode", :js do
-  scenario "Officer views the app in day mode" do
-    visit response_plans_path
+feature "Night mode" do
+  scenario "Officer views the app in day mode", :js do
+    visit new_authentication_path
 
     header_color = get_header_background_color
 
     expect(header_color).to eq("rgb(74, 74, 74)")
   end
 
-  scenario "Officer switches to night mode" do
-    visit response_plans_path
+  scenario "Officer switches to night mode", :js do
+    visit new_authentication_path
     click_on "Night/Day"
 
     header_color = get_header_background_color
@@ -19,6 +19,7 @@ feature "Night mode", :js do
   end
 
   scenario "Officer stays on the page they were viewing" do
+    sign_in_officer
     plan = create(:response_plan)
     path = response_plan_path(plan)
 

--- a/spec/features/officer_leaves_feedback_spec.rb
+++ b/spec/features/officer_leaves_feedback_spec.rb
@@ -4,6 +4,7 @@ require "email_service"
 feature "Feedback" do
   scenario "Officer leaves feedback" do
     allow(EmailService).to receive(:send)
+    sign_in_officer
     response_plan = create(:response_plan)
 
     visit response_plan_path(response_plan)

--- a/spec/features/officer_sign_in_spec.rb
+++ b/spec/features/officer_sign_in_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+feature "Officer sign-in" do
+  scenario "unauthenticated officer is redirected to sign in" do
+    plan = create(:response_plan)
+
+    visit response_plan_path(plan)
+
+    expect(page).to have_content t("authentication.unauthenticated")
+    expect(page).not_to have_content(t("authentication.sign_out.link"))
+    expect(current_path).to eq(new_authentication_path)
+  end
+
+  scenario "user signs in" do
+    officer_name = "Foo Bar"
+    FakeAuthentication.new(name: officer_name).stub_success
+
+    visit new_authentication_path
+    fill_in :authentication_username, with: "Foobar"
+    fill_in :authentication_password, with: "Password"
+    click_on t("authentication.sign_in.link")
+
+    expect(page).
+      to have_content(t("authentication.sign_in.success", name: officer_name))
+    expect(current_path).to eq(response_plans_path)
+  end
+
+  scenario "user fails to sign in" do
+    FakeAuthentication.new.stub_failure
+
+    visit new_authentication_path
+    fill_in :authentication_username, with: "Foobar"
+    fill_in :authentication_password, with: "Password"
+    click_on t("authentication.sign_in.link")
+
+    expect(page).to have_content t("authentication.sign_in.failure")
+    expect(current_path).to eq(new_authentication_path)
+  end
+
+  scenario "authenticated user signs out" do
+    plan = create(:response_plan)
+    sign_in_officer(plan.author)
+
+    visit response_plan_path(plan)
+    click_on t("authentication.sign_out.link")
+
+    expect(page).to have_content t("authentication.sign_out.success")
+    expect(current_path).to eq(new_authentication_path)
+    expect(page.get_rack_session["officer_id"]).to be_nil
+  end
+end

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "Officer views a response plan" do
   scenario "They see the person's basic information" do
+    sign_in_officer
     response_plan = create(
       :response_plan,
       name: "John Doe",
@@ -15,6 +16,7 @@ feature "Officer views a response plan" do
   end
 
   scenario "They see the person's physical characteristics" do
+    sign_in_officer
     response_plan = create(
       :response_plan,
       eye_color: "Green",
@@ -35,6 +37,7 @@ feature "Officer views a response plan" do
   end
 
   scenario "They see the response plan steps" do
+    sign_in_officer
     response_plan = create(:response_plan)
     step_1 = create(:response_strategy, response_plan: response_plan, title: "Call case manager")
     step_2 = create(:response_strategy, response_plan: response_plan, title: "Transport to Harborview")
@@ -46,6 +49,7 @@ feature "Officer views a response plan" do
   end
 
   scenario "They see background information" do
+    sign_in_officer
     background_text = "This is the person's background info"
     response_plan = create(:response_plan, background_info: background_text)
 
@@ -55,6 +59,7 @@ feature "Officer views a response plan" do
   end
 
   scenario "They see emergency contacts" do
+    sign_in_officer
     response_plan = create(:response_plan)
     contact = create(
       :contact,
@@ -74,6 +79,7 @@ feature "Officer views a response plan" do
   end
 
   scenario "They see the preparing officer" do
+    sign_in_officer
     officer = create(:officer, name: "Jacques Clouseau")
     response_plan = create(:response_plan, author: officer)
 
@@ -83,6 +89,7 @@ feature "Officer views a response plan" do
   end
 
   scenario "They see the approving officer" do
+    sign_in_officer
     officer = create(:officer, name: "Jacques Clouseau")
     response_plan = create(:response_plan, approver: officer)
 
@@ -93,6 +100,7 @@ feature "Officer views a response plan" do
 
   context "when there are no safety warnings" do
     pending "they see 'No history of violence'" do
+      sign_in_officer
       response_plan = create(:response_plan)
 
       visit response_plan_path(response_plan)
@@ -103,6 +111,7 @@ feature "Officer views a response plan" do
 
   context "when there are safety warnings" do
     pending "they see the safety warnings" do
+      sign_in_officer
       response_plan = create(:response_plan)
       warning = create(
         :safety_warning,

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "Search", :js do
   scenario "Officer searches by a person's name" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -38,6 +39,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a person's DOB" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -62,6 +64,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a person's name and DOB" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -75,6 +78,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a name with no match" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -88,6 +92,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a DOB with no match" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -101,6 +106,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a name that's slightly off" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -125,6 +131,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a DOB that's slightly off" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -145,6 +152,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a name and DOB that are slightly off" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -158,6 +166,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a name that matches, and DOB that doesn't" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)
@@ -172,6 +181,7 @@ feature "Search", :js do
   end
 
   scenario "Officer searches by a DOB that matches, and name that doesn't" do
+    sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
     response_plan = create(:response_plan, name: name, date_of_birth: dob)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,11 +8,6 @@ require "capybara/poltergeist"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 
-module Features
-  # Extend this module in spec/support/features/*.rb
-  include Formulaic::Dsl
-end
-
 RSpec.configure do |config|
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -1,0 +1,36 @@
+class FakeAuthentication
+  include RSpec::Mocks::ExampleMethods
+
+  def initialize(name: "Foo Bar", username: "foobar")
+    @name = name
+    @username = username
+  end
+
+  attr_reader :name, :username
+
+  def stub_failure
+    allow(Net::LDAP).to receive(:new).and_return(failed_authentication_result)
+  end
+
+  def stub_success
+    allow(Net::LDAP).
+      to receive(:new).and_return(successful_authentication_result)
+  end
+
+  private
+
+  def successful_authentication_result
+    ldap_identity_information = {
+      givenname: [name.split(" ").first],
+      sn: [name.split(" ").last],
+      mail: ["foo@seattle.gov"],
+      cn: [username],
+    }
+
+    double(bind: true, search: [ldap_identity_information])
+  end
+
+  def failed_authentication_result
+    double(bind: false)
+  end
+end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,0 +1,10 @@
+require "rack_session_access/capybara"
+
+module Features
+  # Extend this module in spec/support/features/*.rb
+  include Formulaic::Dsl
+
+  def sign_in_officer(officer = create(:officer))
+    page.set_rack_session(officer_id: officer.id)
+  end
+end


### PR DESCRIPTION
## Problem:

It is a legal requirement to track which officers
access information in our app.

In order to track that information,
we need to identify the officers who are using our system.
## Solution:

Implement officer sign-on using ActiveDirectory.

When a user submits the form to log in,
we use the [net-ldap](https://github.com/ruby-ldap/ruby-net-ldap/) library
to send a request to the LDAP server.

If the result is a successful authentication,
we then search the LDAP server
for the person's information.
We use the returned name and username
to construct an `Officer` model for the user.
## Open Questions
- Do LDAP usernames ever change?
- Will we need/want to update an officer's information based on the LDAP info in the future?
- How do we figure out what unit an officer is in?
- How do we figure out what precinct an officer is in?
## Remaining Tasks
- [x] Refactor everything
- [x] Include a sample response from the `Net::LDAP` search request as a unit test for the `Session` object
- [x] Rename the `Session` object to something like `SignIn`, to avoid name conflicts in the controller
