### PR TITLE
Refactor search specs into unit tests

### DIFF
--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-feature "Search", :js do
-  scenario "Officer searches by a person's name" do
+feature "Search" do
+  scenario "Officer searches and finds a record" do
     sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
@@ -10,35 +10,11 @@ feature "Search", :js do
     visit response_plans_path
 
     search_for(name: "John")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for(name: "Doe")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for(name: "John Doe")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for(name: "Doe John")
-    expect(page).to have_content(response_plan.display_name.upcase)
+    expect(page).to have_content(response_plan.display_name)
     expect(page).to have_content(l(dob))
   end
 
-  pending "Officer searches by part of a person's name" do
-    name = "Christopher Nolan"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
-
-    search_for(name: "Chris")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a person's DOB" do
+  scenario "Officer searches and doesn't find a record" do
     sign_in_officer
     name = "John Doe"
     dob = Date.new(1980, 01, 02)
@@ -46,152 +22,9 @@ feature "Search", :js do
 
     visit response_plans_path
 
-    search_for("DOB" => "1/2/80")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for("DOB" => "1-2-1980")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for("DOB" => "1-2-80")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for("DOB" => "1980-1-2")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a person's name and DOB" do
-    sign_in_officer
-    name = "John Doe"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
-
-    search_for(name: "Doe John", "DOB" => "1/2/80")
-
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a name with no match" do
-    sign_in_officer
-    name = "John Doe"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
     search_for(name: "Mary")
-
     expect(page).to have_content(t("search.results.none"))
-    expect(page).not_to have_content(response_plan.display_name.upcase)
-    expect(page).not_to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a DOB with no match" do
-    sign_in_officer
-    name = "John Doe"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
-
-    search_for("DOB" => "2/3/86")
-    expect(page).to have_content(t("search.results.none"))
-    expect(page).not_to have_content(response_plan.display_name.upcase)
-    expect(page).not_to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a name that's slightly off" do
-    sign_in_officer
-    name = "John Doe"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
-
-    search_for(name: "Jon")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for(name: "Doh")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for(name: "Jon Doh")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for(name: "Doh Jon")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a DOB that's slightly off" do
-    sign_in_officer
-    name = "John Doe"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
-
-    search_for("DOB" => "1/2/81")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for("DOB" => "1/2/79")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-
-    search_for("DOB" => "1/2/80")
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a name and DOB that are slightly off" do
-    sign_in_officer
-    name = "John Doe"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
-
-    search_for(name: "Jon Doh", "DOB" => "1/2/81")
-
-    expect(page).to have_content(response_plan.display_name.upcase)
-    expect(page).to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a name that matches, and DOB that doesn't" do
-    sign_in_officer
-    name = "John Doe"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
-
-    search_for(name: "Jon Doh", "DOB" => "1/2/85")
-
-    expect(page).to have_content(t("search.results.none"))
-    expect(page).not_to have_content(response_plan.display_name.upcase)
-    expect(page).not_to have_content(l(dob))
-  end
-
-  scenario "Officer searches by a DOB that matches, and name that doesn't" do
-    sign_in_officer
-    name = "John Doe"
-    dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-    visit response_plans_path
-
-    search_for(name: "Mary", "DOB" => "1/2/80")
-
-    expect(page).to have_content(t("search.results.none"))
-    expect(page).not_to have_content(response_plan.display_name.upcase)
+    expect(page).not_to have_content(response_plan.display_name)
     expect(page).not_to have_content(l(dob))
   end
 

--- a/spec/models/response_plan_search_spec.rb
+++ b/spec/models/response_plan_search_spec.rb
@@ -1,0 +1,241 @@
+require "rails_helper"
+
+describe ResponsePlanSearch do
+  context "with no parameters" do
+    it "returns all response plans" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new({}).close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+  end
+
+  describe "searching by name" do
+    it "does not return records whose names do not match" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Mary").close_matches
+
+      expect(plans).to eq([])
+    end
+
+    it "returns records that match on first name" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "John").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records that match on last name" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Doe").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records that match on the full name" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "John Doe").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records that match on the reversed name" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Doe John").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    pending "returns records that contain the searched name" do
+      name = "Christopher Nolan"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Chris").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records whose first names sound similar" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Jon").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records whose last names sound similar" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Doh").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records whose full names sound similar" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Jon Doh").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records whose reversed full names sound similar" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Doh Jon").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+  end
+
+  describe "searching by date of birth" do
+    it "does not return records whose dob does not match" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(date_of_birth: "2/3/86").close_matches
+
+      expect(plans).to eq([])
+    end
+
+    it "parses dates in 'mm/dd/yy'" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(date_of_birth: "1/2/80").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "parses dates in 'mm-dd-yyyy'" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(date_of_birth: "1-2-1980").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "parses dates in 'mm-dd-yy'" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(date_of_birth: "1-2-80").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "parses dates in 'yyyy-mm-dd'" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(date_of_birth: "1980-1-2").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records whose DOBs are a year earlier" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(date_of_birth: "1/2/81").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records whose DOBs are a year later" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(date_of_birth: "1/2/79").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records whose DOBs are within a year" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(date_of_birth: "5/2/80").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+  end
+
+  describe "searching by name and DOB" do
+    it "returns exact matches for name and DOB" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Doe John", date_of_birth: "1/2/80").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "returns records whose name and DOB are slightly off" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Jon Doh", date_of_birth: "1/2/81").close_matches
+
+      expect(plans).to eq([response_plan])
+    end
+
+    it "does not return records whose name matches, and DOB doesn't" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Jon Doh", date_of_birth: "1/2/85").close_matches
+
+      expect(plans).to eq([])
+    end
+
+    it "does not return records whose DOB matches, and name doesn't" do
+      name = "John Doe"
+      dob = Date.new(1980, 01, 02)
+      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+
+      plans = ResponsePlanSearch.new(name: "Mary", date_of_birth: "1/2/80").close_matches
+
+      expect(plans).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Problem:

Feature specs are slow.

In our search specs, we were combining tests for many different aspects
of search functionality in single specs.
This contradicts the best practice of only testing one thing per spec.
## Solution:

Test all search functionality in a unit test file for search specs.

Break up those search specs into more specific tests.
