### PR TITLE
make HTML field text visible in night mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Track analytics through Keen.io
 * Officers can sign in with their existing SPD username and password
+
+### Fixed
+
+* Text entered into search or feedback fields is now visible in night mode

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -29,6 +29,7 @@ label {
 #{$all-text-inputs},
 select[multiple=multiple] {
   background-color: $field-background-color;
+  color: $field-text-color;
   border: $base-border;
   border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;

--- a/app/assets/stylesheets/themes/_day.scss
+++ b/app/assets/stylesheets/themes/_day.scss
@@ -46,3 +46,4 @@ $table-header-border-color: shade($base-border-color, 25%);
 $disabled-field-background-color: shade($base-background-color, 5%);
 $fieldset-background-color: tint($base-border-color, 75%);
 $field-background-color: $white;
+$field-text-color: $dark-gray;

--- a/app/assets/stylesheets/themes/_night.scss
+++ b/app/assets/stylesheets/themes/_night.scss
@@ -48,3 +48,4 @@ $table-header-border-color: shade($base-border-color, 25%);
 $disabled-field-background-color: shade($base-background-color, 5%);
 $fieldset-background-color: tint($base-border-color, 75%);
 $field-background-color: $white;
+$field-text-color: $dark-gray;


### PR DESCRIPTION
Fixes #147.
https://trello.com/c/V0jtw2ML/108-text-in-html-fields-does-not-show-in-night-mode
## Problem:

In night mode, the default text color is set to white.
When it's rendered on the white background of form fields,
it is not visible to users.
## Solution:

Explicitly set the color of form field text
in both night mode and day mode
so that it overrides the default text color.
