### PR TITLE
Fix display problems on IE9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+* The site now displays properly on Internet Explorer 9
+
 ## 0.0.1 - 2016-05-30
 
 ### Added

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -37,9 +37,15 @@
     margin-top: $header-height / 6;
   }
 
+  .header-title {
+    display: inline-block;
+  }
+
   .header-actions {
     text-align: right;
     position: relative;
+    display: inline-block;
+    float: right;
   }
 
   a {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />
   <meta name="viewport" content="initial-scale=1" />
+  <meta http-equiv="X-UA-Compatible" content="IE=9" />
 
   <title><%= title %></title>
 


### PR DESCRIPTION
## Problem:

The departments's IE9 browsers are set to display any page on the intranet
in compatibility mode.

This means that the desktop browsers were displaying our page
as if it was being viewed on IE7.
## Solution:

Add a meta tag specifying the compatible version of IE
that the browser should use.
(See http://stackoverflow.com/questions/6348959)

Also, adjust the spacing of some of the header elements.
