### PR TITLE
Improve importing workflow and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,30 @@ programming in style.
 * [Best Practices](http://github.com/thoughtbot/guides/blob/master/best-practices)
 * [Style](http://github.com/thoughtbot/guides/blob/master/style)
 
+## Importing Data
+
+There is a `data.sample` folder in the root of the repository
+that is a template for the data structure that the project knows how to import.
+A folder that mirrors the structure of the `data.sample` folder
+can be imported by running:
+
+```bash
+bundle exec rake import[DATA_PATH]
+```
+
+...where `DATA_PATH` is the file path to the data folder that is being imported.
+
+The `data.sample` folder contains sample response plans
+that are used to seed the application.
+Running `rake db:seed` is equivalent to running `rake import[data.sample]`.
+
+As exhibited in the `data.sample` folder,
+each data folder should contain a file called `response_plans.csv`,
+which defines the information for the response plans in the app.
+Each response plan defined in `response_plans.csv`
+can have a corresponding folder in the `images` subdirectory,
+which contains images for the response plan.
+
 ## Managing Application Lifecycle
 
 ```bash

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,13 +1,13 @@
 # This file should contain all the record creation
 # needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed
+# The data can then be loaded with `rake db:seed`
 # (or created alongside the db with db:setup).
 
 require "csv_importer"
 
-file = "data.sample/response_plans.csv"
-puts "Importing: #{file}"
+data_dir = "data.sample"
+puts "Importing: #{data_dir}"
 
 Officer.destroy_all
 ResponsePlan.destroy_all
-CsvImporter.new(file).create_records
+CsvImporter.new(data_dir).create_records

--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -1,11 +1,19 @@
 require "csv"
 
 class CsvImporter
-  def initialize(csv_path)
-    @csv_path = csv_path
+  def initialize(data_dir)
+    @data_dir = data_dir
   end
 
-  attr_reader :csv_path
+  attr_reader :data_dir
+
+  def csv_path
+    Rails.root.join(data_dir, "response_plans.csv")
+  end
+
+  def image_dir
+    Rails.root.join(data_dir, "images")
+  end
 
   def create_records
     data.map do |csv_row|
@@ -65,7 +73,6 @@ class CsvImporter
   end
 
   def parse_image(csv_row)
-    image_dir = Rails.root + "#{File.dirname(csv_path)}/images"
     image_path = "#{image_dir}/#{csv_row["Last Name"].downcase}_#{csv_row["First Name"].downcase}/*".gsub(" ", "_")
     images = Dir.glob(image_path)
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,9 +1,9 @@
 task :import, [:filename] => [:environment] do |t, args|
   require "csv_importer"
-  file = args[:filename]
+  data_dir = args[:filename]
 
-  puts "Importing: #{file}"
+  puts "Importing: #{data_dir}"
 
   ResponsePlan.destroy_all
-  CsvImporter.new(file).create_records
+  CsvImporter.new(data_dir).create_records
 end


### PR DESCRIPTION
The API has changed from:

```
rake import[data.sample/response_plans.csv]
```

to:

```
rake import[data.sample]
```
