### PR TITLE
Add "Officer Safety not yet implemented" box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+* A placeholder section for officer safety notes,
+  until the actual notes get built into the app.
+
 ## [0.0.2] - 2016-06-02
 
 ### Fixed

--- a/app/views/response_plans/show.html.erb
+++ b/app/views/response_plans/show.html.erb
@@ -9,6 +9,7 @@
   </div>
 
   <div class="right-column">
+    <%= render "sections/safety_warnings" %>
     <%= render "sections/response_plan" %>
     <%= render "sections/background_info" %>
     <%= render "sections/contacts" %>

--- a/app/views/sections/_safety_warnings.html.erb
+++ b/app/views/sections/_safety_warnings.html.erb
@@ -7,14 +7,11 @@
   </div>
 
   <div class="section-body">
-    <% if @response_plan.safety_warnings.any? %>
-      <ul>
-        <% @response_plan.safety_warnings.each do |warning| %>
-          <li><%= warning.description %></li>
-        <% end %>
-      </ul>
-    <% else %>
-      <%= t("response_plan.safety.none") %>
-    <% end %>
+    <p>Officer safety information is still under development.</p>
+
+    <p>
+    For information about <%= @response_plan.first_name %>,
+    please see the <strong>Response Plan</strong> section below.
+    </p>
   </div>
 </section>

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,4 +1,3 @@
-
 task :import, [:filename] => [:environment] do |t, args|
   require "csv_importer"
   file = args[:filename]


### PR DESCRIPTION
Problem:

The Crisis Response Team isn't comfortable releasing response plans
without any mention of officer safety information.

Solution:

Add an "Officer Safety" box
with a message that officer safety information is not yet implemented.
