### PR TITLE
Generate analytics tokens for officers and plans

### DIFF
--- a/app/models/concerns/analytics.rb
+++ b/app/models/concerns/analytics.rb
@@ -1,0 +1,7 @@
+module Analytics
+  def generate_analytics_token
+    begin
+      self.analytics_token = SecureRandom.hex
+    end while self.class.exists?(analytics_token: analytics_token)
+  end
+end

--- a/app/models/officer.rb
+++ b/app/models/officer.rb
@@ -1,4 +1,7 @@
 class Officer < ActiveRecord::Base
+  include Analytics
+  before_create :generate_analytics_token
+
   has_many :authored_response_plans,
     class_name: "ResponsePlan",
     foreign_key: :author_id,

--- a/app/models/response_plan.rb
+++ b/app/models/response_plan.rb
@@ -1,6 +1,9 @@
 class ResponsePlan < ActiveRecord::Base
   include PgSearch
 
+  include Analytics
+  before_create :generate_analytics_token
+
   has_many :contacts, dependent: :destroy
   has_many :response_strategies, -> { order(:priority) }, dependent: :destroy
   has_many :safety_warnings, dependent: :destroy

--- a/db/migrate/20160606153404_add_analytics_tokens.rb
+++ b/db/migrate/20160606153404_add_analytics_tokens.rb
@@ -1,0 +1,6 @@
+class AddAnalyticsTokens < ActiveRecord::Migration
+  def change
+    add_column :officers, :analytics_token, :string
+    add_column :response_plans, :analytics_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160605182652) do
+ActiveRecord::Schema.define(version: 20160606153404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,13 +63,14 @@ ActiveRecord::Schema.define(version: 20160605182652) do
   end
 
   create_table "officers", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string   "name",            null: false
     t.string   "unit"
     t.string   "title"
     t.string   "phone"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
     t.string   "username"
+    t.string   "analytics_token"
   end
 
   add_index "officers", ["username"], name: "index_officers_on_username", unique: true, using: :btree
@@ -92,6 +93,7 @@ ActiveRecord::Schema.define(version: 20160605182652) do
     t.integer  "approver_id"
     t.datetime "approved_at"
     t.text     "background_info"
+    t.string   "analytics_token"
   end
 
   add_index "response_plans", ["approver_id"], name: "index_response_plans_on_approver_id", using: :btree

--- a/spec/models/officer_spec.rb
+++ b/spec/models/officer_spec.rb
@@ -1,6 +1,9 @@
-require 'rails_helper'
+require "rails_helper"
+require "shared/analytics_token"
 
 RSpec.describe Officer, type: :model do
+  it_should_behave_like "it has an analytics token"
+
   describe "associations" do
     it { should have_many(:authored_response_plans).dependent(:destroy) }
     it { should have_many(:approved_response_plans).dependent(:destroy) }

--- a/spec/models/response_plan_spec.rb
+++ b/spec/models/response_plan_spec.rb
@@ -1,6 +1,9 @@
-require 'rails_helper'
+require "rails_helper"
+require "shared/analytics_token"
 
 RSpec.describe ResponsePlan, type: :model do
+  it_should_behave_like "it has an analytics token"
+
   describe "validations" do
     it { should allow_value("Female").for(:sex) }
     it { should allow_value("Male").for(:sex) }

--- a/spec/shared/analytics_token.rb
+++ b/spec/shared/analytics_token.rb
@@ -1,0 +1,23 @@
+RSpec.shared_examples "it has an analytics token" do |parameter|
+  it "skips an analytics token if it already exists in the DB" do
+    existing = create(factory_name)
+    allow(SecureRandom).to receive(:hex).
+      and_return(existing.analytics_token, :new_analytics_token)
+
+    new = create(factory_name)
+
+    expect(new.analytics_token).not_to eq(existing.analytics_token)
+    expect(new.analytics_token).to eq("new_analytics_token")
+    expect(SecureRandom).to have_received(:hex).at_least(2).times
+  end
+
+  it "should generate an analytics token after create" do
+    object = create(factory_name)
+
+    expect(object.analytics_token).not_to be_nil
+  end
+
+  def factory_name
+    described_class.to_s.underscore.to_sym
+  end
+end


### PR DESCRIPTION
## Problem:

We need to track officers and response plans in our analytics,
but the officers' and subjects' identities are sensitive information.
We cannot directly share their names or usernames,
so thus far we've been using their database IDs.

Tracking based on database IDs is unsustainable,
because many routine database operations can re-assign those IDs.
When that happens, there would be a break in the analytics,
and we would not be able to use previously-collected analytics
with analytics collected after the change.
## Solution:

Generate random "analytics tokens" for response plans and officers,
which we can use to identify the records in our analytics.
The new analytics tokens can be carried over with the records
through any database changes,
and they don't contain any identifying information about officers
or subjects of the response plans.

We considered some other identifiers
as alternatives to the random tokens:
- name
- hashed name
- officer id
- username
- hashed username

The name and username are identifiable, so they can't be used.

The hashed name and username are not identifiable,
but they also cannot be easily queried in the database
because they are calculated values that aren't stored.

The officer ID is a four-digit alphanumeric string that appears before
the user's `displayName` in their LDAP entry.
This would be a promising candidate, but not all officers have an ID.
