### PR TITLE
Small fixes to get ready for real crisis data

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -88,6 +88,7 @@
       margin-top: 0;
       position: relative;
       width: auto;
+      background-color: inherit;
 
       a {
         border-top: none;

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -13,11 +13,11 @@
 
         <%= link_to(
           "Change Log",
-          page_path("about"),
+          page_path("changelog"),
         ) %>
 
         <%= link_to(
-          "Night/Day",
+          "Light/Dark",
           preferences_path(theme: :toggle),
           method: :post,
           class: "change-theme",

--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -36,7 +36,8 @@ class CsvImporter
   end
 
   def data
-    CSV.parse(File.read(csv_path), headers: true)
+    data = File.read(csv_path).gsub(" ", " ")
+    CSV.parse(data, headers: true)
   end
 
   def parse_response_plan(csv_row)
@@ -153,7 +154,7 @@ class CsvImporter
   end
 
   def filter(array_of_hashes)
-    array_of_hashes.select { |hash| hash.values.compact.any?  }
+    array_of_hashes.select { |hash| hash.values.compact.any?(&:present?)  }
   end
 
   def parse_author_attrs(csv_row)

--- a/spec/features/night_mode_spec.rb
+++ b/spec/features/night_mode_spec.rb
@@ -11,7 +11,7 @@ feature "Night mode" do
 
   scenario "Officer switches to night mode", :js do
     visit new_authentication_path
-    click_on "Night/Day"
+    click_on "Light/Dark"
 
     header_color = get_header_background_color
 
@@ -24,7 +24,7 @@ feature "Night mode" do
     path = response_plan_path(plan)
 
     visit path
-    click_on "Night/Day"
+    click_on "Light/Dark"
 
     expect(current_path).to eq(path)
   end

--- a/spec/features/officer_views_static_pages_spec.rb
+++ b/spec/features/officer_views_static_pages_spec.rb
@@ -12,6 +12,6 @@ feature "Static pages" do
     visit response_plans_path
     click_on "Change Log"
 
-    expect(page).to have_content("Change Log")
+    expect(page).to have_content("0.0.1")
   end
 end


### PR DESCRIPTION
## Problem:
- The collapsible header links were displaying with a differnet
  background color when on a large screen in Internet Explorer.
  When they're shown on a large screen,
  they should inherit the header background color.
- Some strangely-encoded spaces in the CSV file were being translated
  into `&nbsp;` in the HTML.
  This made some sections, such as Gregory Tannen's response plan steps,
  to overflow their parent element.
- The "Change Log" link was linking to the "About" page
- Martha Tannen had two empty contacts
## Solution:
- Make sure the header colors inherit correctly on large screens
- Clean all input from the CSV file to make sure it's using the proper
  encoding for spaces
- Fix the Change Log link
- Skip contacts with blank information
