### PR TITLE
Fix more small display bugs (found with real data)

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -47,10 +47,19 @@
 
   .identity-name {
     margin-top: $header-height / 6;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .header-title {
     display: inline-block;
+    width: 60%;
+  }
+
+  .header-title,
+  .header-actions {
+    height: $header-height;
   }
 
   .header-actions {
@@ -58,6 +67,7 @@
     position: relative;
     display: inline-block;
     float: right;
+    width: 40%;
   }
 
   .menu-collapsed {

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -50,17 +50,10 @@
 .search-result {
   @include span-columns(4 of 4);
 
-  img {
-    max-width: 40%;
-
-    @include media($medium-screen-up) {
-      max-width: none;
-    }
-  }
-
   .search-result-labels {
-    width: 50%;
+    width: 55%;
     float: right;
+    overflow: hidden;
 
     @include media($medium-screen-up) {
       width: auto;
@@ -90,7 +83,7 @@
     border: $dark-border;
     height: 6em;
     margin: 0;
-    max-width: 100%;
+    max-width: 40%;
 
     @include media($medium-screen-up) {
       display: block;
@@ -98,6 +91,7 @@
       margin-bottom: $small-spacing;
       margin-left: auto;
       margin-right: auto;
+      max-width: none;
     }
   }
 


### PR DESCRIPTION
## Problem:
- Long names in the header throw off the header layout
- wide pictures throw off the layout of search results
- long names throw off the layout of search results
## Solution:
- Make long names fade into ellipsis in the header
- cut off long names in the search results
- limit picture width in search results
