### PR TITLE
Don't overwrite existing response plans on import

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -4,6 +4,5 @@ task :import, [:filename] => [:environment] do |t, args|
 
   puts "Importing: #{data_dir}"
 
-  ResponsePlan.destroy_all
   CsvImporter.new(data_dir).create_records
 end

--- a/spec/lib/csv_importer_spec.rb
+++ b/spec/lib/csv_importer_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require "csv_importer"
+
+describe CsvImporter do
+  context "When a response plan does not exist" do
+    it "creates a response plan" do
+      importer = CsvImporter.new("data.sample")
+
+      expect { importer.create_records }.to change(ResponsePlan, :count).by(3)
+    end
+  end
+
+  context "When a response plan already exists with the same name" do
+    it "does not overwrite its analytics token" do
+      names = { first_name: "Martha", last_name: "Tannen" }
+      plan = create(:response_plan, names)
+      token = plan.analytics_token
+      importer = CsvImporter.new("data.sample")
+
+      importer.create_records
+
+      new_plans = ResponsePlan.where(names)
+      expect(new_plans.count).to eq(1)
+      expect(new_plans.first.analytics_token).to eq(token)
+    end
+
+    it "updates the information" do
+      names = { first_name: "Martha", last_name: "Tannen" }
+      plan = create(:response_plan, names.merge(sex: "Male"))
+      importer = CsvImporter.new("data.sample")
+
+      importer.create_records
+
+      plan.reload
+      expect(plan.sex).to eq("Female")
+    end
+  end
+end


### PR DESCRIPTION
## Problem:

If there are future changes to response plans,
running an import script would overwrite the plans' analytics tokens.
This would break our analytics picture into uncontinuous blocks
that wouldn't deliver the insights we need.
## Solution:

Instead of erasing all response plans and re-creating them on import,
instead check to see if a response plan exists
with the first and last names we expect.

If there is an existing response plan, update its information.
If not, create a new response plan from scratch.
## Small changes

Remove unused code for importing officer safety notes,
which aren't currently being displayed.
