### PR TITLE
Gracefully report malformed date of birth searches

### DIFF
--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -7,12 +7,6 @@
     font-size: 1.6em;
   }
 
-  .fields {
-    @include media($medium-screen-up) {
-      @include span-columns(8 of 12);
-    }
-  }
-
   label {
     @include span-columns(2 of 8);
     text-align: right;
@@ -24,16 +18,33 @@
     @include omega;
   }
 
-  .actions {
-    @include media($medium-screen-up) {
-      @include span-columns(4 of 12);
-    }
+  .field_with_errors input {
+    margin-bottom: 0;
+  }
+
+  .error {
+    @include omega;
+    @include shift(2);
+    @include span-columns(6 of 8);
+    background-color: $red;
+    color: $white;
+    padding: 0 $small-spacing;
   }
 
   input[type="submit"] {
     @include span-columns(3 of 4);
     @include shift(1);
     padding: $base-spacing;
+  }
+
+  @include media($medium-screen-up) {
+    .actions {
+      @include span-columns(4 of 12);
+    }
+
+    .fields {
+      @include span-columns(8 of 12);
+    }
   }
 }
 

--- a/app/controllers/response_plans_controller.rb
+++ b/app/controllers/response_plans_controller.rb
@@ -7,6 +7,7 @@ class ResponsePlansController < ApplicationController
 
   def index
     @search = ResponsePlanSearch.new(search_params)
+    @search.validate
     @response_plans = @search.close_matches
   end
 

--- a/app/models/response_plan_search.rb
+++ b/app/models/response_plan_search.rb
@@ -1,5 +1,6 @@
 class ResponsePlanSearch
   include ActiveModel::Model
+  validate :proper_date_format
 
   attr_accessor :name, :date_of_birth
 
@@ -10,7 +11,7 @@ class ResponsePlanSearch
       response_plans = response_plans.search(name)
     end
 
-    if date_of_birth.present?
+    if parsed_date_of_birth.present?
       response_plans = response_plans.where(date_of_birth: date_of_birth_range)
     end
 
@@ -19,11 +20,17 @@ class ResponsePlanSearch
 
   private
 
+  def proper_date_format
+    if date_of_birth.present? && parsed_date_of_birth.nil?
+      errors.add(:date_of_birth, "... not recognized as a valid date.")
+    end
+  end
+
   def date_of_birth_range
     (parsed_date_of_birth - 1.year)..(parsed_date_of_birth + 1.year)
   end
 
   def parsed_date_of_birth
-    Chronic.parse(date_of_birth)
+    @parsed_date_of_birth ||= Chronic.parse(date_of_birth)
   end
 end

--- a/app/views/response_plans/index.html.erb
+++ b/app/views/response_plans/index.html.erb
@@ -2,15 +2,17 @@
   Response Plan App
 <% end %>
 
-<%= form_for(@search, url: response_plans_path, method: :get, html: { class: "search" }) do |f| %>
+<%= simple_form_for(
+  @search,
+  url: response_plans_path,
+  method: :get,
+  html: { class: "search" },
+) do |f| %>
   <h1>Search for a Response Plan</h1>
 
   <div class="fields">
-    <%= f.label :name %>
-    <%= f.text_field :name, placeholder: "e.g. Doe, John A" %>
-
-    <%= f.label :date_of_birth, "DOB" %>
-    <%= f.text_field :date_of_birth, placeholder: "e.g. 05-08-1970" %>
+    <%= f.input :name, placeholder: "e.g. Doe, John A" %>
+    <%= f.input :date_of_birth, label: "DOB", placeholder: "e.g. 05-08-1970" %>
   </div>
 
   <div class="actions">

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -28,6 +28,15 @@ feature "Search" do
     expect(page).not_to have_content(l(dob))
   end
 
+  scenario "Officer searches for a malformed date" do
+    sign_in_officer
+
+    visit response_plans_path
+
+    search_for("DOB" => "foobar")
+    expect(page).to have_content("... not recognized as a valid date.")
+  end
+
   def search_for(params)
     within(".search") do
       fill_form_and_submit(:response_plan_search, params)

--- a/spec/models/response_plan_search_spec.rb
+++ b/spec/models/response_plan_search_spec.rb
@@ -1,241 +1,251 @@
 require "rails_helper"
 
 describe ResponsePlanSearch do
-  context "with no parameters" do
-    it "returns all response plans" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+  describe "validations" do
+    it "validates that dates are in a recognized format" do
+      search = ResponsePlanSearch.new(date_of_birth: "foo")
 
-      plans = ResponsePlanSearch.new({}).close_matches
+      search.validate
 
-      expect(plans).to eq([response_plan])
+      expect(search.errors[:date_of_birth]).to include("... not recognized as a valid date.")
     end
   end
 
-  describe "searching by name" do
-    it "does not return records whose names do not match" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+  describe "#close_matches" do
+    context "with no parameters" do
+      it "returns all response plans" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
 
-      plans = ResponsePlanSearch.new(name: "Mary").close_matches
+        plans = ResponsePlanSearch.new({}).close_matches
 
-      expect(plans).to eq([])
+        expect(plans).to eq([response_plan])
+      end
     end
 
-    it "returns records that match on first name" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+    describe "searching by name" do
+      it "does not return records whose names do not match" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
 
-      plans = ResponsePlanSearch.new(name: "John").close_matches
+        plans = ResponsePlanSearch.new(name: "Mary").close_matches
 
-      expect(plans).to eq([response_plan])
+        expect(plans).to eq([])
+      end
+
+      it "returns records that match on first name" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "John").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records that match on last name" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "Doe").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records that match on the full name" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "John Doe").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records that match on the reversed name" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "Doe John").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      pending "returns records that contain the searched name" do
+        name = "Christopher Nolan"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "Chris").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records whose first names sound similar" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "Jon").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records whose last names sound similar" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "Doh").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records whose full names sound similar" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "Jon Doh").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records whose reversed full names sound similar" do
+        name = "John Doe"
+        response_plan = create(:response_plan, name: name)
+
+        plans = ResponsePlanSearch.new(name: "Doh Jon").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
     end
 
-    it "returns records that match on last name" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+    describe "searching by date of birth" do
+      it "does not return records whose dob does not match" do
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, date_of_birth: dob)
 
-      plans = ResponsePlanSearch.new(name: "Doe").close_matches
+        plans = ResponsePlanSearch.new(date_of_birth: "2/3/86").close_matches
 
-      expect(plans).to eq([response_plan])
+        expect(plans).to eq([])
+      end
+
+      it "parses dates in 'mm/dd/yy'" do
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, date_of_birth: dob)
+
+        plans = ResponsePlanSearch.new(date_of_birth: "1/2/80").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      pending "parses dates in 'mmddyyyy'" do
+        match = create(:response_plan, date_of_birth: Date.new(1980, 01, 02))
+        _mismatch = create(:response_plan, date_of_birth: Date.new(1978, 01, 02))
+
+        plans = ResponsePlanSearch.new(date_of_birth: "01021980").close_matches
+
+        expect(plans).to eq([match])
+      end
+
+      it "ignores dates in an unrecognized format" do
+        plan = create(:response_plan)
+
+        plans = ResponsePlanSearch.new(date_of_birth: "foo").close_matches
+
+        expect(plans).to eq([plan])
+      end
+
+      it "parses dates in 'mm-dd-yyyy'" do
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, date_of_birth: dob)
+
+        plans = ResponsePlanSearch.new(date_of_birth: "1-2-1980").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "parses dates in 'mm-dd-yy'" do
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, date_of_birth: dob)
+
+        plans = ResponsePlanSearch.new(date_of_birth: "1-2-80").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "parses dates in 'yyyy-mm-dd'" do
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, date_of_birth: dob)
+
+        plans = ResponsePlanSearch.new(date_of_birth: "1980-1-2").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records whose DOBs are a year earlier" do
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, date_of_birth: dob)
+
+        plans = ResponsePlanSearch.new(date_of_birth: "1/2/81").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records whose DOBs are a year later" do
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, date_of_birth: dob)
+
+        plans = ResponsePlanSearch.new(date_of_birth: "1/2/79").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
+
+      it "returns records whose DOBs are within a year" do
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, date_of_birth: dob)
+
+        plans = ResponsePlanSearch.new(date_of_birth: "5/2/80").close_matches
+
+        expect(plans).to eq([response_plan])
+      end
     end
 
-    it "returns records that match on the full name" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+    describe "searching by name and DOB" do
+      it "returns exact matches for name and DOB" do
+        name = "John Doe"
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, name: name, date_of_birth: dob)
 
-      plans = ResponsePlanSearch.new(name: "John Doe").close_matches
+        plans = ResponsePlanSearch.new(name: "Doe John", date_of_birth: "1/2/80").close_matches
 
-      expect(plans).to eq([response_plan])
-    end
+        expect(plans).to eq([response_plan])
+      end
 
-    it "returns records that match on the reversed name" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+      it "returns records whose name and DOB are slightly off" do
+        name = "John Doe"
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, name: name, date_of_birth: dob)
 
-      plans = ResponsePlanSearch.new(name: "Doe John").close_matches
+        plans = ResponsePlanSearch.new(name: "Jon Doh", date_of_birth: "1/2/81").close_matches
 
-      expect(plans).to eq([response_plan])
-    end
+        expect(plans).to eq([response_plan])
+      end
 
-    pending "returns records that contain the searched name" do
-      name = "Christopher Nolan"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+      it "does not return records whose name matches, and DOB doesn't" do
+        name = "John Doe"
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, name: name, date_of_birth: dob)
 
-      plans = ResponsePlanSearch.new(name: "Chris").close_matches
+        plans = ResponsePlanSearch.new(name: "Jon Doh", date_of_birth: "1/2/85").close_matches
 
-      expect(plans).to eq([response_plan])
-    end
+        expect(plans).to eq([])
+      end
 
-    it "returns records whose first names sound similar" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
+      it "does not return records whose DOB matches, and name doesn't" do
+        name = "John Doe"
+        dob = Date.new(1980, 01, 02)
+        response_plan = create(:response_plan, name: name, date_of_birth: dob)
 
-      plans = ResponsePlanSearch.new(name: "Jon").close_matches
+        plans = ResponsePlanSearch.new(name: "Mary", date_of_birth: "1/2/80").close_matches
 
-      expect(plans).to eq([response_plan])
-    end
-
-    it "returns records whose last names sound similar" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(name: "Doh").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "returns records whose full names sound similar" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(name: "Jon Doh").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "returns records whose reversed full names sound similar" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(name: "Doh Jon").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-  end
-
-  describe "searching by date of birth" do
-    it "does not return records whose dob does not match" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(date_of_birth: "2/3/86").close_matches
-
-      expect(plans).to eq([])
-    end
-
-    it "parses dates in 'mm/dd/yy'" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(date_of_birth: "1/2/80").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "parses dates in 'mm-dd-yyyy'" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(date_of_birth: "1-2-1980").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "parses dates in 'mm-dd-yy'" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(date_of_birth: "1-2-80").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "parses dates in 'yyyy-mm-dd'" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(date_of_birth: "1980-1-2").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "returns records whose DOBs are a year earlier" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(date_of_birth: "1/2/81").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "returns records whose DOBs are a year later" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(date_of_birth: "1/2/79").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "returns records whose DOBs are within a year" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(date_of_birth: "5/2/80").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-  end
-
-  describe "searching by name and DOB" do
-    it "returns exact matches for name and DOB" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(name: "Doe John", date_of_birth: "1/2/80").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "returns records whose name and DOB are slightly off" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(name: "Jon Doh", date_of_birth: "1/2/81").close_matches
-
-      expect(plans).to eq([response_plan])
-    end
-
-    it "does not return records whose name matches, and DOB doesn't" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(name: "Jon Doh", date_of_birth: "1/2/85").close_matches
-
-      expect(plans).to eq([])
-    end
-
-    it "does not return records whose DOB matches, and name doesn't" do
-      name = "John Doe"
-      dob = Date.new(1980, 01, 02)
-      response_plan = create(:response_plan, name: name, date_of_birth: dob)
-
-      plans = ResponsePlanSearch.new(name: "Mary", date_of_birth: "1/2/80").close_matches
-
-      expect(plans).to eq([])
+        expect(plans).to eq([])
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/PpdhOlwM/120-bug-searching-by-an-invalid-date-of-birth
## Problem:

If an officer searches for a date of birth in an unrecognized format,
the application throws a server error.
## Solution:

For malformed DOBs in searches,
ignore them when finding search results
and display an error to the user in the UI.

![crisis_response](https://cloud.githubusercontent.com/assets/829576/16105336/4e6111ea-333e-11e6-99c5-014a51b1133f.png)
## Next up
- Find the exact date formats that they tried to search by,
  and support that in the search.
