### PR TITLE
On small screens, collapse response plan steps

### DIFF
--- a/app/assets/images/arrow_down-day.svg
+++ b/app/assets/images/arrow_down-day.svg
@@ -1,0 +1,4 @@
+<svg fill="#0096a6" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"/>
+    <path d="M0-.75h24v24H0z" fill="none"/>
+</svg>

--- a/app/assets/images/arrow_down-night.svg
+++ b/app/assets/images/arrow_down-night.svg
@@ -1,0 +1,4 @@
+<svg fill="#50e2e3" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"/>
+    <path d="M0-.75h24v24H0z" fill="none"/>
+</svg>

--- a/app/assets/images/arrow_up-day.svg
+++ b/app/assets/images/arrow_up-day.svg
@@ -1,0 +1,4 @@
+<svg fill="#0096a6" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/app/assets/images/arrow_up-night.svg
+++ b/app/assets/images/arrow_up-night.svg
@@ -1,0 +1,4 @@
+<svg fill="#50e2e3" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/app/assets/javascripts/application/response_strategies.js
+++ b/app/assets/javascripts/application/response_strategies.js
@@ -1,0 +1,14 @@
+$(function() {
+  $(".mobile-collapsed .expand").on("click", function(event) {
+    var target = $(event.target);
+    var parent = $(event.target.parentElement);
+
+    var originalText = target.text();
+
+    parent.toggleClass("mobile-collapsed");
+    target.text(target.data("text-swap"));
+    target.data("text-swap", target.text());
+
+    return false;
+  });
+});

--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -16,6 +16,7 @@
 @import "location";
 @import "menu";
 @import "response_plans";
+@import "response_strategies";
 @import "search";
 @import "section";
 @import "sign_in";

--- a/app/assets/stylesheets/_response_plans.scss
+++ b/app/assets/stylesheets/_response_plans.scss
@@ -1,4 +1,5 @@
 $radius: 6px;
+$bullet-size: 3rem;
 
 .safety-warnings {
   li {
@@ -9,39 +10,4 @@ $radius: 6px;
 .response-plan {
   @include span-columns(8 of 8);
   counter-reset: response-strategy-counter;
-
-  .response-strategy {
-    $bullet-size: 3rem;
-
-    margin-top: $base-spacing;
-    margin-left: $bullet-size;
-    display: inline-block;
-    position: relative;
-
-    &:before {
-      background-image: $bullet-background;
-      background-repeat: no-repeat;
-      background-size: 2em 2em;
-      color: $section-body-background;
-      content: counter(response-strategy-counter);
-      counter-increment: response-strategy-counter;
-      font-size: 1rem;
-      height: 2em;
-      left: - $bullet-size;
-      line-height: 2em;
-      position: absolute;
-      text-align: center;
-      width: 2em;
-    }
-
-    h3 {
-      @include heavy-font;
-      font-size: 1.2em;
-    }
-
-    p {
-      color: $secondary-text-color;
-      margin-bottom: $base-spacing;
-    }
-  }
 }

--- a/app/assets/stylesheets/_response_strategies.scss
+++ b/app/assets/stylesheets/_response_strategies.scss
@@ -1,0 +1,83 @@
+.response-strategy {
+  display: inline-block;
+  margin-bottom: $base-spacing;
+  margin-top: $base-spacing;
+  position: relative;
+
+  &:before {
+    background-image: $bullet-background;
+    background-repeat: no-repeat;
+    background-size: 2em 2em;
+    color: $section-body-background;
+    content: counter(response-strategy-counter);
+    counter-increment: response-strategy-counter;
+    font-size: 1rem;
+    height: 2em;
+    left: 0;
+    line-height: 2em;
+    position: absolute;
+    text-align: center;
+    width: 2em;
+  }
+
+  h3 {
+    @include heavy-font;
+    font-size: 1.2em;
+    margin-bottom: $small-spacing;
+    margin-left: $bullet-size;
+  }
+
+  p {
+    color: $secondary-text-color;
+  }
+
+  .expand:after {
+    $arrow-size: 1.6em;
+    background-image: $arrow_up;
+    background-size: contain;
+    content: "";
+    display: inline-block;
+    height: $arrow-size;
+    vertical-align: middle;
+    width: $arrow-size;
+  }
+}
+
+.mobile-collapsed {
+  .expand:after {
+    background-image: $arrow_down;
+  }
+
+  p {
+    max-height: 3em;
+    overflow: hidden;
+    position: relative;
+    text-overflow: ellipsis;
+
+    &:after {
+      background-image: linear-gradient($transparent, $section-body-background);
+      bottom: 0;
+      content: "";
+      display: block;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  }
+
+  @include media($medium-screen-up) {
+    p {
+      max-height: 100%;
+      margin-left: $bullet-size;
+    }
+
+    p:after {
+      display: none;
+    }
+
+    .expand {
+      display: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -30,6 +30,9 @@ $base-z-index: 0;
 $header-height: 3 * $base-spacing;
 $page-width: 90%;
 
+// Universal colors
+$transparent: rgba(0, 0, 0, 0);
+
 // Shadows
 $shadow-level-1: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
 $shadow-level-2: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);

--- a/app/assets/stylesheets/themes/_day.scss
+++ b/app/assets/stylesheets/themes/_day.scss
@@ -39,6 +39,8 @@ $contact-notes-color: $secondary-text-color;
 $bullet-background: url("/assets/circle.svg");
 $zoom_in_image: url("zoom_in-day.svg");
 $zoom_out_image: url("zoom_out-day.svg");
+$arrow_up: url("arrow_up-day.svg");
+$arrow_down: url("arrow_down-day.svg");
 
 // Borders
 $base-border-color: $light-gray;

--- a/app/assets/stylesheets/themes/_night.scss
+++ b/app/assets/stylesheets/themes/_night.scss
@@ -41,6 +41,8 @@ $contact-notes-color: darken($base-font-color, 25%);
 $bullet-background: url("/assets/circle-white.svg");
 $zoom_in_image: url("zoom_in-night.svg");
 $zoom_out_image: url("zoom_out-night.svg");
+$arrow_up: url("arrow_up-night.svg");
+$arrow_down: url("arrow_down-night.svg");
 
 // Borders
 $base-border-color: $light-gray;

--- a/app/views/response_plans/show.html.erb
+++ b/app/views/response_plans/show.html.erb
@@ -17,7 +17,7 @@
 
   <div class="right-column">
     <%= render "sections/safety_warnings" %>
-    <%= render "sections/response_plan" %>
+    <%= render "sections/response_strategies" %>
     <%= render "sections/background_info" %>
     <%= render "sections/about" %>
   </div>

--- a/app/views/sections/_response_strategies.html.erb
+++ b/app/views/sections/_response_strategies.html.erb
@@ -8,9 +8,10 @@
 
   <div class="section-body">
     <% @response_plan.response_strategies.each do |strategy| %>
-      <div class="response-strategy">
+      <div class="response-strategy mobile-collapsed">
         <h3><%= strategy.title %></h3>
         <p><%= strategy.description %></p>
+        <a href="#" class="expand" data-text-swap="Hide">Read More</a>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Problem

On small screens, the text of response plan steps
takes up a lot of vertical space,
forcing the user to scroll far down the page
to get to following information.
## Solution

Display the first two lines of the response plan step descriptions,
with a link to toggle showing the full description.
## Implementation Notes

The designs called for ellipses for text that overflowed
the height of the collapsed container.
This is not possible to do with pure CSS,
and we would need to introduce a new dependency such as [ftellipsis](https://github.com/ftlabs/ftellipsis).
More details are available on [StackOverflow](http://stackoverflow.com/questions/7004006/is-vertical-text-overflow-possible-with-css3).

Inspiration for the code to swap out the "expand" link text
came from [this article](https://css-tricks.com/swapping-out-text-five-different-ways/).

I attempted to animate height according to [this article](http://css3.bradshawenterprises.com/animating_height/),
but it ended up being pretty jumpy and not smooth on mobile.
Decided against it.
