### PR TITLE
Let admin officers approve response plans

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_officer
-    Officer.find_by(id: session[:officer_id])
+    @current_officer ||= Officer.find_by(id: session[:officer_id])
   end
 
   def officer_signed_in?

--- a/app/controllers/response_plans_controller.rb
+++ b/app/controllers/response_plans_controller.rb
@@ -61,6 +61,23 @@ class ResponsePlansController < ApplicationController
     end
   end
 
+  def approve
+    plan = ResponsePlan.find(params[:id])
+    plan.approver = current_officer
+
+    if plan.save
+      redirect_to(
+        response_plan_path(plan),
+        notice: t("response_plans.approval.success", name: plan.name),
+      )
+    else
+      redirect_to(
+        response_plan_path(plan),
+        alert: t("response_plans.approval.failure"),
+      )
+    end
+  end
+
   private
 
   def search_params

--- a/app/models/response_plan.rb
+++ b/app/models/response_plan.rb
@@ -83,7 +83,7 @@ class ResponsePlan < ActiveRecord::Base
   def approved?
     approved_at.present? &&
       approver.present? &&
-      approved_at > updated_at
+      approved_at > (updated_at - 1.second)
   end
 
   def approver=(value)

--- a/app/views/response_plans/index.html.erb
+++ b/app/views/response_plans/index.html.erb
@@ -27,8 +27,12 @@
   <% if @response_plans.any? %>
     <% @response_plans.each do |response_plan| %>
       <%= link_to response_plan_path(response_plan), class: "search-result" do %>
-        <span class="needs-approval-banner">Needs Approval</span>
+        <% unless response_plan.approved? %>
+          <span class="needs-approval-banner">Needs Approval</span>
+        <% end %>
+
         <%= image_tag response_plan.profile_image_url %>
+
         <div class="search-result-labels">
           <span class="search-result-name"><%= response_plan.display_name %></span>
           <span class="search-result-dob"><%= l response_plan.date_of_birth %></span>

--- a/app/views/response_plans/show.html.erb
+++ b/app/views/response_plans/show.html.erb
@@ -3,9 +3,15 @@
 <% end %>
 
 <div class="main">
+
   <% unless @response_plan.approved? %>
     <div class="needs-approval">
-      <%= t("response_plans.needs_approval") %>
+      <%= t("response_plans.approval.required") %>
+      <%= link_to(
+        t("response_plans.approval.action"),
+        approve_response_plan_path(@response_plan),
+        method: :patch
+      ) %>
     </div>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,11 @@ en:
       success: Created a response plan for %{name}
     update:
       success: "Updated %{name}'s response plan"
-    needs_approval: This response plan will not be visible to patrol officers until it is approved.
+    approval:
+      required: This response plan will not be visible to patrol officers until it is approved.
+      action: Approve
+      success: "Approved %{name}'s response plan. It is now visible to patrol officers"
+      failure: You cannot approve response plans that you wrote.
 
   search:
     form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,12 @@ Rails.application.routes.draw do
 
   resources :feedbacks, only: [:new, :create]
   resources :preferences, only: :create
-  resources :response_plans, except: [:destroy]
+
+  resources :response_plans, except: [:destroy] do
+    member do
+      patch :approve
+    end
+  end
 
   root to: "response_plans#index"
 end

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -135,7 +135,7 @@ feature "Officer views a response plan" do
 
       visit response_plan_path(response_plan)
 
-      expect(page).not_to have_content(t("response_plans.needs_approval"))
+      expect(page).not_to have_content(t("response_plans.approval.required"))
     end
 
     scenario "They see the approving officer" do
@@ -158,7 +158,33 @@ feature "Officer views a response plan" do
 
       visit response_plan_path(response_plan)
 
-      expect(page).to have_content(t("response_plans.needs_approval"))
+      expect(page).to have_content(t("response_plans.approval.required"))
+    end
+
+    scenario "an admin approves it" do
+      admin = create(:officer, username: "admin")
+      stub_admin_permissions(admin)
+      sign_in_officer(admin)
+      response_plan = create(:response_plan, approver: nil)
+
+      visit response_plan_path(response_plan)
+      click_on t("response_plans.approval.action")
+
+      expect(response_plan.reload).to be_approved
+      expect(page).to have_content(t("response_plans.approval.success", name: response_plan.name))
+    end
+
+    scenario "the author cannot approve it" do
+      admin = create(:officer, username: "admin")
+      stub_admin_permissions(admin)
+      sign_in_officer(admin)
+      response_plan = create(:response_plan, approver: nil, author: admin)
+
+      visit response_plan_path(response_plan)
+      click_on t("response_plans.approval.action")
+
+      expect(response_plan.reload).not_to be_approved
+      expect(page).to have_content(t("response_plans.approval.failure"))
     end
   end
 

--- a/spec/features/response_plan_form_spec.rb
+++ b/spec/features/response_plan_form_spec.rb
@@ -18,7 +18,7 @@ feature "Response Plan Form" do
       click_on "Create Response plan"
 
       expect(page).to have_content(t("response_plans.create.success", name: "John Doe"))
-      expect(page).to have_content(t("response_plans.needs_approval"))
+      expect(page).to have_content(t("response_plans.approval.required"))
       expect(page).to have_content("John")
       expect(page).to have_content("Doe")
       expect(page).to have_content(l(Date.new(1980, 1, 2)))
@@ -48,7 +48,7 @@ feature "Response Plan Form" do
 
       expect(page).
         to have_content(t("response_plans.create.success", name: "John Doe"))
-      expect(page).to have_content(t("response_plans.needs_approval"))
+      expect(page).to have_content(t("response_plans.approval.required"))
       expect(page).to have_content("John")
       expect(page).to have_content("Doe")
       expect(page).to have_content(l(Date.new(1980, 1, 2)))
@@ -84,7 +84,12 @@ feature "Response Plan Form" do
 
   context "Editing an existing response plan" do
     scenario "updated plan needs re-approval" do
-      plan = create(:response_plan, first_name: "Jane", last_name: "Doe")
+      plan = create(
+        :response_plan,
+        first_name: "Jane",
+        last_name: "Doe",
+        approved_at: 1.day.ago,
+      )
       officer = create(:officer, username: "foo")
       stub_admin_permissions(officer)
       sign_in_officer(officer)
@@ -93,7 +98,7 @@ feature "Response Plan Form" do
       fill_in "First name", with: "Mary"
       click_on "Update Response plan"
 
-      expect(page).to have_content(t("response_plans.needs_approval"))
+      expect(page).to have_content(t("response_plans.approval.required"))
       expect(page).
         to have_content(t("response_plans.update.success", name: "Mary Doe"))
       expect(page).to have_content("Mary")


### PR DESCRIPTION
## Feature

**As** an admin,
**When** an officer fills out a new response plan,
**I want to** review the response plan and approve it
**So that** it can be available to patrol officers.
## Implementation
- Show an "approve" button on the response plan page.
- Create a new, non-restful controller action for approvals.
- Display an error if an author tries to approve their own plan.
## Minor changes
- Cache the `current_officer` query on each request.
