### PR TITLE
Extract a `Person` model from `ResponsePlan`

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,0 +1,101 @@
+class Person < ActiveRecord::Base
+  include PgSearch
+
+  include Analytics
+  before_create :generate_analytics_token
+
+  RACE_CODES = {
+    "AFRICAN AMERICAN/BLACK" => "B",
+    "AMERICAN INDIAN/ALASKAN NATIVE" => "I",
+    "ASIAN (ALL)/PACIFIC ISLANDER" => "A",
+    "UNKNOWN" => "U",
+    "WHITE" => "W",
+  }.freeze
+
+  SEX_CODES = {
+    "Male" => "M",
+    "Female" => "F",
+  }.freeze
+
+  EYE_COLORS = [
+    :black,
+    :blue,
+    :brown,
+    :gray,
+    :green,
+    :hazel,
+    :maroon,
+    :multicolored,
+    :pink,
+    :unknown,
+  ].freeze
+
+  HAIR_COLORS = [
+    :bald,
+    :black,
+    :blonde,
+    :brown,
+    :grey,
+    :red,
+  ].freeze
+
+  has_many :response_plans
+
+  validates :sex, inclusion: SEX_CODES.keys, allow_nil: true
+  validates :race, inclusion: RACE_CODES.keys, allow_nil: true
+  validates :date_of_birth, presence: true
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+
+  pg_search_scope(
+    :search,
+    against: [:first_name, :last_name],
+    using: [:tsearch, :dmetaphone, :trigram],
+  )
+
+  def active_response_plan
+    response_plans.where.not(approved_at: nil).order(:approved_at).last
+  end
+
+  def display_name
+    "#{last_name}, #{first_name}"
+  end
+
+  def eye_color
+    super || "Unknown"
+  end
+
+  def hair_color
+    super || "Unknown"
+  end
+
+  def name
+    "#{first_name} #{last_name}"
+  end
+
+  def name=(value)
+    (self.first_name, self.last_name) = value.split
+  end
+
+  def response_plan
+    response_plans.last
+  end
+
+  def shorthand_description
+    [
+      RACE_CODES.fetch(race) + SEX_CODES.fetch(sex),
+      height_in_feet_and_inches,
+      weight_in_pounds ? "#{weight_in_pounds} lb" : nil,
+    ].compact.join(" – ")
+  end
+
+  private
+
+  def height_in_feet_and_inches
+    if height_in_inches
+      "#{height_in_inches / 12}'#{height_in_inches % 12}\""
+    else
+      nil
+    end
+  end
+end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -39,50 +39,50 @@ class Search
   end
 
   def close_matches
-    response_plans = ResponsePlan
+    people = Person
 
     if name.present?
-      response_plans = response_plans.search(name)
+      people = people.search(name)
     end
 
     if date_of_birth.present?
       date_of_birth_range = range(date_of_birth, 1.year)
-      response_plans = response_plans.where(date_of_birth: date_of_birth_range)
+      people = people.where(date_of_birth: date_of_birth_range)
     end
 
     if age.present?
       expected_dob = (Date.today - age.to_i.years)
       expected_dob_range = range(expected_dob, 5.years)
-      response_plans = response_plans.where(date_of_birth: expected_dob_range)
+      people = people.where(date_of_birth: expected_dob_range)
     end
 
     if height.present?
       height_range = range(height.to_i, 3)
-      response_plans = response_plans.where(height_in_inches: height_range)
+      people = people.where(height_in_inches: height_range)
     end
 
     if weight.present?
       weight_range = range(weight.to_i, 25)
-      response_plans = response_plans.where(weight_in_pounds: weight_range)
+      people = people.where(weight_in_pounds: weight_range)
     end
 
     if eye_color.any?
-      response_plans = response_plans.where(eye_color: eye_color)
+      people = people.where(eye_color: eye_color)
     end
 
     if hair_color.any?
-      response_plans = response_plans.where(hair_color: hair_color)
+      people = people.where(hair_color: hair_color)
     end
 
     if race.any?
-      response_plans = response_plans.where(race: race)
+      people = people.where(race: race)
     end
 
     if sex.any?
-      response_plans = response_plans.where(sex: sex)
+      people = people.where(sex: sex)
     end
 
-    response_plans.all
+    people.all
   end
 
   def partial_matches

--- a/app/views/application/_analytics.html.erb
+++ b/app/views/application/_analytics.html.erb
@@ -14,7 +14,7 @@ var pageData = {
   params: <%= params.to_json.html_safe %>,
   page_controller_path: "<%= [params[:controller], params[:action]].join('.') %>",
   officer_token: "<%= current_officer.try(:analytics_token) %>",
-  response_plan_token: "<%= @response_plan.try(:analytics_token) %>",
+  response_plan_token: "<%= @response_plan.try(:person).try(:analytics_token) %>",
   referrer: document.referrer,
   browser: bowser,
   keen: {

--- a/app/views/application/_identity.html.erb
+++ b/app/views/application/_identity.html.erb
@@ -1,9 +1,9 @@
 <div class="identity">
   <span class="identity-name">
-    <%= response_plan.last_name.upcase %>,
-    <%= response_plan.first_name.titleize %>
+    <%= person.last_name.upcase %>,
+    <%= person.first_name.titleize %>
   </span>
   <span class="identity-dob">
-    <%= l response_plan.date_of_birth %>
+    <%= l person.date_of_birth %>
   </span>
 </div>

--- a/app/views/response_plans/_form.html.erb
+++ b/app/views/response_plans/_form.html.erb
@@ -1,21 +1,29 @@
 <%= simple_form_for(@response_plan) do |f| %>
   <div class="response_plan_form">
-    <%= f.input :first_name %>
-    <%= f.input :last_name %>
-    <%= f.input :date_of_birth, label: "DOB", as: :string %>
+    <%= f.fields_for :person do |person| %>
+      <%= person.input :first_name %>
+      <%= person.input :last_name %>
+      <%= person.input :date_of_birth, label: "DOB", as: :string %>
+    <% end %>
 
     <%= render "nested_form", f: f, relationship: :aliases, html_classes: [] %>
 
-    <%= f.input :race, collection: ResponsePlan::RACE_CODES.keys %>
-    <%= f.input :sex, collection: ResponsePlan::SEX_CODES.keys %>
-    <%= f.input :weight_in_pounds, label: "Weight" %>
-    <%= f.input :height_in_inches, label: "Height" %>
-    <%= f.input :eye_color %>
-    <%= f.input :hair_color %>
-    <%= f.input :scars_and_marks %>
+    <%= f.fields_for :person do |person| %>
+      <%= person.input :race, collection: Person::RACE_CODES.keys %>
+      <%= person.input :sex, collection: Person::SEX_CODES.keys %>
+      <%= person.input :weight_in_pounds, label: "Weight" %>
+      <%= person.input :height_in_inches, label: "Height" %>
+      <%= person.input :eye_color %>
+      <%= person.input :hair_color %>
+      <%= person.input :scars_and_marks %>
+    <% end %>
+
     <%= f.input :background_info %>
-    <%= f.input :location_name %>
-    <%= f.input :location_address %>
+
+    <%= f.fields_for :person do |person| %>
+      <%= person.input :location_name %>
+      <%= person.input :location_address %>
+    <% end %>
 
     <%= render "nested_form", f: f, relationship: :contacts, html_classes: ["multi-field"] %>
     <%= render "nested_form", f: f, relationship: :images, html_classes: [] %>

--- a/app/views/response_plans/_recently_viewed.html.erb
+++ b/app/views/response_plans/_recently_viewed.html.erb
@@ -10,8 +10,8 @@
       <%= image_tag response_plan.profile_image_url %>
 
       <div class="recently-viewed-plan-labels">
-        <span class="recently-viewed-plan-name"><%= response_plan.display_name %></span>
-        <span class="recently-viewed-plan-dob"><%= l response_plan.date_of_birth %></span>
+        <span class="recently-viewed-plan-name"><%= response_plan.person.display_name %></span>
+        <span class="recently-viewed-plan-dob"><%= l response_plan.person.date_of_birth %></span>
       </div>
     <% end %>
   <% end %>

--- a/app/views/response_plans/_search_form.html.erb
+++ b/app/views/response_plans/_search_form.html.erb
@@ -31,8 +31,8 @@
 
     <div class="physicals-search-fields collapsed">
       <%= f.input :age %>
-      <%= f.input :sex, as: :check_boxes, collection: ResponsePlan::SEX_CODES.keys %>
-      <%= f.input :race, as: :check_boxes, collection: ResponsePlan::RACE_CODES.keys %>
+      <%= f.input :sex, as: :check_boxes, collection: Person::SEX_CODES.keys %>
+      <%= f.input :race, as: :check_boxes, collection: Person::RACE_CODES.keys %>
       <%= f.input :height %>
       <%= f.input :weight %>
 
@@ -40,7 +40,7 @@
         <%= f.input(
           :hair_color,
           as: :check_boxes,
-          collection: ResponsePlan::HAIR_COLORS,
+          collection: Person::HAIR_COLORS,
         ) %>
         <%= link_to(
           t("search.options.show"),
@@ -56,7 +56,7 @@
         <%= f.input(
           :eye_color,
           as: :check_boxes,
-          collection: ResponsePlan::EYE_COLORS,
+          collection: Person::EYE_COLORS,
         ) %>
         <%= link_to(
           t("search.options.show"),

--- a/app/views/response_plans/_search_result.html.erb
+++ b/app/views/response_plans/_search_result.html.erb
@@ -1,7 +1,7 @@
 <%= link_to response_plan, class: "search-result" do %>
   <%= image_tag response_plan.profile_image_url %>
   <div class="search-result-info">
-    <%= render "identity", response_plan: response_plan %>
-    <div class="description"><%= response_plan.shorthand_description %></div>
+    <%= render "identity", person: response_plan.person %>
+    <div class="description"><%= response_plan.person.shorthand_description %></div>
   </div>
 <% end %>

--- a/app/views/response_plans/_search_results.html.erb
+++ b/app/views/response_plans/_search_results.html.erb
@@ -23,8 +23,8 @@
 
     <div class="results">
       <div class="loose-matches">
-        <% if @search.close_matches.any? %>
-          <% @search.close_matches.each do |plan| %>
+        <% if @response_plans.any? %>
+          <% @response_plans.each do |plan| %>
             <%= render "search_result", response_plan: plan %>
           <% end %>
         <% else %>

--- a/app/views/response_plans/edit.html.erb
+++ b/app/views/response_plans/edit.html.erb
@@ -2,4 +2,4 @@
   Edit Response Plan
 <% end %>
 
-<%= render "form", title: "Edit #{@response_plan.name.titleize}'s Response Plan" %>
+<%= render "form", title: "Edit #{@response_plan.person.name.titleize}'s Response Plan" %>

--- a/app/views/response_plans/show.html.erb
+++ b/app/views/response_plans/show.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:header) do %>
-  <%= render "identity", response_plan: @response_plan %>
+  <%= render "identity", person: @response_plan.person %>
 <% end %>
 
 <div class="main">

--- a/app/views/sections/_location.html.erb
+++ b/app/views/sections/_location.html.erb
@@ -1,7 +1,7 @@
-<% if @response_plan.location_address.present? %>
+<% if @response_plan.person.location_address.present? %>
   <section
     class="location"
-    data-address="<%= @response_plan.location_address %>"
+    data-address="<%= @response_plan.person.location_address %>"
     >
     <div class="section-header section-header-muted">
       <div class="section-header-text">
@@ -11,7 +11,7 @@
 
     <div class="section-body">
       <span class="location-name">
-        <%= @response_plan.location_name %>
+        <%= @response_plan.person.location_name %>
       </span>
 
       <span class="location-address">

--- a/app/views/sections/_profile.html.erb
+++ b/app/views/sections/_profile.html.erb
@@ -1,6 +1,6 @@
 <section class="profile">
   <div class="section-body">
-    <%= render "identity", response_plan: response_plan %>
+    <%= render "identity", person: response_plan.person %>
 
     <hr/>
 
@@ -20,22 +20,22 @@
 
     <div class="physical">
       <span class="shorthand-description">
-        <%= response_plan.shorthand_description %>
+        <%= response_plan.person.shorthand_description %>
       </span>
 
       <span class="hair-color">
         <%= image_tag("physical/hair-#{theme}.svg") %>
-        <%= response_plan.hair_color.to_s.humanize %>
+        <%= response_plan.person.hair_color.to_s.humanize %>
       </span>
 
       <span class="eye-color">
         <%= image_tag("physical/eye-#{theme}.svg") %>
-        <%= response_plan.eye_color.to_s.humanize %>
+        <%= response_plan.person.eye_color.to_s.humanize %>
       </span>
 
       <span class="scars-marks">
         <span class="scars-marks-label">SMT</span>
-        <%= response_plan.scars_and_marks.to_s.humanize %>
+        <%= response_plan.person.scars_and_marks.to_s.humanize %>
       </span>
     </div>
   </div>

--- a/app/views/sections/_safety_warnings.html.erb
+++ b/app/views/sections/_safety_warnings.html.erb
@@ -10,7 +10,7 @@
     <p>Officer safety information is still under development.</p>
 
     <p>
-    For information about <%= @response_plan.first_name %>,
+    For information about <%= @response_plan.person.first_name %>,
     please see the <strong>Response Plan</strong> section below.
     </p>
   </div>

--- a/db/migrate/20160715214553_extract_people_from_response_plans.rb
+++ b/db/migrate/20160715214553_extract_people_from_response_plans.rb
@@ -1,0 +1,114 @@
+class ResponsePlan < ActiveRecord::Base; end
+class Person < ActiveRecord::Base; end
+
+class ExtractPeopleFromResponsePlans < ActiveRecord::Migration
+  PERSON_ATTRS = [
+    :analytics_token,
+    :created_at,
+    :date_of_birth,
+    :eye_color,
+    :first_name,
+    :hair_color,
+    :height_in_inches,
+    :last_name,
+    :location_address,
+    :location_name,
+    :race,
+    :scars_and_marks,
+    :sex,
+    :updated_at,
+    :weight_in_pounds,
+  ]
+
+  def up
+    # create table
+    create_table :people do |t|
+      t.timestamps null: false
+      t.string   :first_name
+      t.string   :last_name
+      t.string   :sex
+      t.string   :race
+      t.integer  :height_in_inches
+      t.integer  :weight_in_pounds
+      t.string   :hair_color
+      t.string   :eye_color
+      t.date     :date_of_birth
+      t.string   :scars_and_marks
+      t.string   :analytics_token
+      t.string   :location_name
+      t.string   :location_address
+    end
+
+    # copy attributes from response_plan to person
+    execute(<<-SQL)
+      INSERT INTO people (#{PERSON_ATTRS.join(',')})
+      SELECT #{PERSON_ATTRS.join(',')}
+      FROM response_plans
+    SQL
+
+    # add person_id to response_plan
+    add_reference :response_plans, :person, index: true, foreign_key: true
+
+    # associate response_plan with person
+    execute(<<-SQL)
+    UPDATE response_plans
+    SET person_id = (
+      SELECT id FROM people
+      WHERE analytics_token = response_plans.analytics_token
+    );
+    SQL
+
+    # remove attributes from response plan
+    change_table :response_plans do |t|
+      t.remove :first_name
+      t.remove :last_name
+      t.remove :sex
+      t.remove :race
+      t.remove :height_in_inches
+      t.remove :weight_in_pounds
+      t.remove :hair_color
+      t.remove :eye_color
+      t.remove :date_of_birth
+      t.remove :scars_and_marks
+      t.remove :analytics_token
+      t.remove :location_name
+      t.remove :location_address
+    end
+  end
+
+  def down
+    # add attributes to response plan
+    change_table :response_plans do |t|
+      t.string   :first_name
+      t.string   :last_name
+      t.string   :sex
+      t.string   :race
+      t.integer  :height_in_inches
+      t.integer  :weight_in_pounds
+      t.string   :hair_color
+      t.string   :eye_color
+      t.date     :date_of_birth
+      t.string   :scars_and_marks
+      t.string   :analytics_token
+      t.string   :location_name
+      t.string   :location_address
+    end
+
+    # copy attributes from person to response_plan
+    PERSON_ATTRS.each do |attr|
+      execute(<<-SQL)
+        UPDATE response_plans
+        SET #{attr} = (
+          SELECT #{attr} FROM people
+          WHERE response_plans.person_id = people.id
+        );
+      SQL
+    end
+
+    # remove person_id from response_plan
+    remove_reference :response_plans, :person
+
+    # drop table
+    drop_table :people
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160707223238) do
+ActiveRecord::Schema.define(version: 20160715214553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20160707223238) do
 
   add_index "officers", ["username"], name: "index_officers_on_username", unique: true, using: :btree
 
-  create_table "response_plans", force: :cascade do |t|
+  create_table "people", force: :cascade do |t|
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
     t.string   "first_name"
@@ -98,18 +98,25 @@ ActiveRecord::Schema.define(version: 20160707223238) do
     t.string   "eye_color"
     t.date     "date_of_birth"
     t.string   "scars_and_marks"
-    t.integer  "author_id",        null: false
-    t.integer  "approver_id"
-    t.datetime "approved_at"
-    t.text     "background_info"
     t.string   "analytics_token"
     t.string   "location_name"
     t.string   "location_address"
+  end
+
+  create_table "response_plans", force: :cascade do |t|
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.integer  "author_id",       null: false
+    t.integer  "approver_id"
+    t.datetime "approved_at"
+    t.text     "background_info"
     t.text     "private_notes"
+    t.integer  "person_id"
   end
 
   add_index "response_plans", ["approver_id"], name: "index_response_plans_on_approver_id", using: :btree
   add_index "response_plans", ["author_id"], name: "index_response_plans_on_author_id", using: :btree
+  add_index "response_plans", ["person_id"], name: "index_response_plans_on_person_id", using: :btree
 
   create_table "response_strategies", force: :cascade do |t|
     t.integer  "priority"
@@ -134,6 +141,7 @@ ActiveRecord::Schema.define(version: 20160707223238) do
   add_foreign_key "aliases", "response_plans"
   add_foreign_key "contacts", "response_plans"
   add_foreign_key "images", "response_plans"
+  add_foreign_key "response_plans", "people"
   add_foreign_key "response_strategies", "response_plans"
   add_foreign_key "safety_warnings", "response_plans"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,10 +29,7 @@ FactoryGirl.define do
     phone "222-333-4444"
   end
 
-  factory :response_plan do
-    aliases []
-    author
-    approver
+  factory :person do
     name "John Doe"
     sex "Male"
     race "AFRICAN AMERICAN/BLACK"
@@ -41,6 +38,13 @@ FactoryGirl.define do
     hair_color "black"
     eye_color "blue"
     date_of_birth { 25.years.ago }
+  end
+
+  factory :response_plan do
+    person
+    aliases []
+    author
+    approver
     updated_at { 1.second.ago }
   end
 

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -5,16 +5,17 @@ feature "Officer views a response plan" do
 
   scenario "They see the person's basic information" do
     sign_in_officer
-    response_plan = create(
-      :response_plan,
+    person = create(
+      :person,
       name: "John Doe",
       date_of_birth: Date.new(1980),
     )
+    response_plan = create(:response_plan, person: person)
 
     visit response_plan_path(response_plan)
 
     expect(page).to have_content("DOE, John")
-    expect(page).to have_content(l(response_plan.date_of_birth))
+    expect(page).to have_content(l(person.date_of_birth))
   end
 
   scenario "They see the person's pictures", :js do
@@ -43,8 +44,8 @@ feature "Officer views a response plan" do
 
   scenario "They see the person's physical characteristics" do
     sign_in_officer
-    response_plan = create(
-      :response_plan,
+    person = create(
+      :person,
       eye_color: "Green",
       hair_color: "Brown",
       height_in_inches: 70,
@@ -53,6 +54,7 @@ feature "Officer views a response plan" do
       sex: "Male",
       weight_in_pounds: 180,
     )
+    response_plan = create(:response_plan, person: person)
 
     visit response_plan_path(response_plan)
 
@@ -65,11 +67,8 @@ feature "Officer views a response plan" do
   scenario "They see the person's aliases" do
     sign_in_officer
     aliases = ["Mark Smith", "Joe Andrews"]
-    response_plan = create(
-      :response_plan,
-      name: "John Doe",
-      alias_list: aliases,
-    )
+    person = create(:person, name: "John Doe")
+    response_plan = create(:response_plan, alias_list: aliases, person: person)
 
     visit response_plan_path(response_plan)
 
@@ -171,7 +170,9 @@ feature "Officer views a response plan" do
       click_on t("response_plans.approval.action")
 
       expect(response_plan.reload).to be_approved
-      expect(page).to have_content(t("response_plans.approval.success", name: response_plan.name))
+      expect(page).to have_content(
+        t("response_plans.approval.success", name: response_plan.person.name)
+      )
     end
 
     scenario "the author cannot approve it" do

--- a/spec/features/response_plan_form_spec.rb
+++ b/spec/features/response_plan_form_spec.rb
@@ -84,12 +84,8 @@ feature "Response Plan Form" do
 
   context "Editing an existing response plan" do
     scenario "updated plan needs re-approval" do
-      plan = create(
-        :response_plan,
-        first_name: "Jane",
-        last_name: "Doe",
-        approved_at: 1.day.ago,
-      )
+      person = create(:person, first_name: "Jane", last_name: "Doe")
+      plan = create(:response_plan, person: person, approved_at: 1.day.ago)
       officer = create(:officer, username: "foo")
       stub_admin_permissions(officer)
       sign_in_officer(officer)

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -3,23 +3,23 @@ require "rails_helper"
 feature "Search" do
   scenario "Officer searches and finds a record" do
     sign_in_officer
-    name = "John Doe"
     dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
+    person = create(:person, name: "John Doe", date_of_birth: dob)
+    create_plans_for(person)
 
     visit response_plans_path
 
     search_for(name: "John")
     expect(page).to have_content("DOE, John")
     expect(page).to have_content(l(dob))
-    expect(page).to have_content(response_plan.shorthand_description)
+    expect(page).to have_content(person.shorthand_description)
   end
 
   scenario "Officer searches and doesn't find a record" do
     sign_in_officer
-    name = "John Doe"
     dob = Date.new(1980, 01, 02)
-    response_plan = create(:response_plan, name: name, date_of_birth: dob)
+    person = create(:person, name: "John Doe", date_of_birth: dob)
+    create_plans_for(person)
 
     visit response_plans_path
 
@@ -47,11 +47,12 @@ feature "Search" do
 
   feature "Physicals search", :js do
     scenario "Officer searches by age" do
-      match = create(:response_plan, date_of_birth: 20.years.ago)
-      close_match = create(:response_plan, date_of_birth: 25.years.ago)
-      other = create(:response_plan, date_of_birth: 50.years.ago)
-      sign_in_officer
+      match = create(:person, date_of_birth: 20.years.ago)
+      close_match = create(:person, date_of_birth: 25.years.ago)
+      other = create(:person, date_of_birth: 50.years.ago)
+      create_plans_for(match, close_match, other)
 
+      sign_in_officer
       visit response_plans_path
       click_on t("search.physicals.show")
       fill_in "Age", with: 20
@@ -63,10 +64,11 @@ feature "Search" do
     end
 
     scenario "Officer searches by gender" do
-      male = create(:response_plan, sex: "Male")
-      female = create(:response_plan, sex: "Female")
-      sign_in_officer
+      male = create(:person, sex: "Male")
+      female = create(:person, sex: "Female")
+      create_plans_for(male, female)
 
+      sign_in_officer
       visit response_plans_path
       click_on t("search.physicals.show")
       check_option(:sex, female.sex)
@@ -77,11 +79,12 @@ feature "Search" do
     end
 
     scenario "Officer searches by race" do
-      white = create(:response_plan, race: "WHITE")
-      asian = create(:response_plan, race: "ASIAN (ALL)/PACIFIC ISLANDER")
-      other = create(:response_plan, race: "AFRICAN AMERICAN/BLACK")
-      sign_in_officer
+      white = create(:person, race: "WHITE")
+      asian = create(:person, race: "ASIAN (ALL)/PACIFIC ISLANDER")
+      other = create(:person, race: "AFRICAN AMERICAN/BLACK")
+      create_plans_for(white, asian, other)
 
+      sign_in_officer
       visit response_plans_path
       click_on t("search.physicals.show")
       check_option(:race, white.race)
@@ -94,11 +97,12 @@ feature "Search" do
     end
 
     scenario "Officer searches by weight" do
-      match = create(:response_plan, weight_in_pounds: 150)
-      close_match = create(:response_plan, weight_in_pounds: 175)
-      other = create(:response_plan, weight_in_pounds: 300)
-      sign_in_officer
+      match = create(:person, weight_in_pounds: 150)
+      close_match = create(:person, weight_in_pounds: 175)
+      other = create(:person, weight_in_pounds: 300)
+      create_plans_for(match, close_match, other)
 
+      sign_in_officer
       visit response_plans_path
       click_on t("search.physicals.show")
       fill_in "Weight", with: 150
@@ -110,11 +114,12 @@ feature "Search" do
     end
 
     scenario "Officer searches by height" do
-      match = create(:response_plan, height_in_inches: 60)
-      close_match = create(:response_plan, height_in_inches: 63)
-      other = create(:response_plan, height_in_inches: 72)
-      sign_in_officer
+      match = create(:person, height_in_inches: 60)
+      close_match = create(:person, height_in_inches: 63)
+      other = create(:person, height_in_inches: 72)
+      create_plans_for(match, close_match, other)
 
+      sign_in_officer
       visit response_plans_path
       click_on t("search.physicals.show")
       fill_in "Height", with: 60
@@ -126,11 +131,12 @@ feature "Search" do
     end
 
     scenario "Officer searches by hair color" do
-      brown = create(:response_plan, hair_color: "Brown")
-      black = create(:response_plan, hair_color: "Black")
-      other = create(:response_plan, hair_color: "Blonde")
-      sign_in_officer
+      brown = create(:person, hair_color: "Brown")
+      black = create(:person, hair_color: "Black")
+      other = create(:person, hair_color: "Blonde")
+      create_plans_for(brown, black, other)
 
+      sign_in_officer
       visit response_plans_path
       click_on t("search.physicals.show")
       check_option(:hair_color, "Brown")
@@ -143,11 +149,12 @@ feature "Search" do
     end
 
     scenario "Officer searches by eye color" do
-      blue = create(:response_plan, eye_color: :blue, weight_in_pounds: 120)
-      brown = create(:response_plan, eye_color: :brown, weight_in_pounds: 130)
-      other = create(:response_plan, eye_color: :green, weight_in_pounds: 140)
-      sign_in_officer
+      blue = create(:person, eye_color: :blue, weight_in_pounds: 120)
+      brown = create(:person, eye_color: :brown, weight_in_pounds: 130)
+      other = create(:person, eye_color: :green, weight_in_pounds: 140)
+      create_plans_for(blue, brown, other)
 
+      sign_in_officer
       visit response_plans_path
       click_on t("search.physicals.show")
       check_option(:eye_color, "blue")
@@ -167,6 +174,12 @@ feature "Search" do
 
     def run_search
       first(".actions input").trigger("click")
+    end
+  end
+
+  def create_plans_for(*people)
+    people.each do |person|
+      create(:response_plan, person: person)
     end
   end
 end

--- a/spec/lib/csv_importer_spec.rb
+++ b/spec/lib/csv_importer_spec.rb
@@ -13,35 +13,35 @@ describe CsvImporter do
   context "When a response plan already exists with the same name" do
     it "does not overwrite its analytics token" do
       names = { first_name: "Martha", last_name: "Tannen" }
-      plan = create(:response_plan, names)
-      token = plan.analytics_token
-      importer = CsvImporter.new("data.sample")
+      person = create(:person, names)
+      plan = create(:response_plan, person: person)
+      token = plan.person.analytics_token
 
-      importer.create_records
+      CsvImporter.new("data.sample").create_records
 
-      new_plans = ResponsePlan.where(names)
+      person = Person.where(names)
+      new_plans = ResponsePlan.where(person: person)
       expect(new_plans.count).to eq(1)
-      expect(new_plans.first.analytics_token).to eq(token)
+      expect(new_plans.first.person.analytics_token).to eq(token)
     end
 
     it "updates the information" do
       names = { first_name: "Martha", last_name: "Tannen" }
-      plan = create(:response_plan, names.merge(sex: "Male"))
-      importer = CsvImporter.new("data.sample")
+      person = create(:person, names.merge(sex: "Male"))
+      plan = create(:response_plan, person: person)
 
-      importer.create_records
+      CsvImporter.new("data.sample").create_records
 
       plan.reload
-      expect(plan.sex).to eq("Female")
+      expect(plan.person.sex).to eq("Female")
     end
   end
 
   it "imports multiple images" do
-    importer = CsvImporter.new("data.sample")
+    CsvImporter.new("data.sample").create_records
 
-    importer.create_records
-
-    plan = ResponsePlan.find_by(first_name: "Martha", last_name: "Tannen")
+    person = Person.find_by(first_name: "Martha", last_name: "Tannen")
+    plan = ResponsePlan.find_by(person: person)
     expect(plan.images.count).to eq(2)
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+require "shared/analytics_token"
+
+RSpec.describe Person, type: :model do
+  it_should_behave_like "it has an analytics token"
+
+  describe "associations" do
+    it { should have_many(:response_plans) }
+  end
+
+  describe "validations" do
+    it { should allow_value("Female").for(:sex) }
+    it { should allow_value("Male").for(:sex) }
+    it { should allow_value(nil).for(:sex) }
+    it { should_not allow_value("FEMALE").for(:sex) }
+    it { should_not allow_value("M").for(:sex) }
+
+    it { should allow_value("AFRICAN AMERICAN/BLACK").for(:race) }
+    it { should allow_value("AMERICAN INDIAN/ALASKAN NATIVE").for(:race) }
+    it { should allow_value("ASIAN (ALL)/PACIFIC ISLANDER").for(:race) }
+    it { should allow_value("UNKNOWN").for(:race) }
+    it { should allow_value("WHITE").for(:race) }
+    it { should allow_value(nil).for(:race) }
+    it { should_not allow_value("BLACK").for(:race) }
+    it { should_not allow_value("W").for(:race) }
+    it { should_not allow_value("White").for(:race) }
+  end
+
+  describe "#active_response_plan" do
+    it "returns the most recent approved response plan" do
+      person = create(:person)
+      plans = [
+        create(:response_plan, person: person, approved_at: 1.month.ago),
+        create(:response_plan, person: person, approved_at: 1.week.ago),
+        create(:response_plan, person: person, approved_at: nil, approver: nil),
+      ]
+
+      expect(person.active_response_plan).to eq(plans.second)
+    end
+  end
+
+  describe "#display_name" do
+    it "displays last name, first name" do
+      person = build(:person, first_name: "John", last_name: "Doe")
+
+      expect(person.display_name).to eq("Doe, John")
+    end
+  end
+
+  describe "#shorthand_description" do
+    it "starts with a letter representing race" do
+      expect(shorthand_for(race: "AFRICAN AMERICAN/BLACK")).to start_with("B")
+      expect(shorthand_for(race: "AMERICAN INDIAN/ALASKAN NATIVE")).to start_with("I")
+      expect(shorthand_for(race: "ASIAN (ALL)/PACIFIC ISLANDER")).to start_with("A")
+      expect(shorthand_for(race: "UNKNOWN")).to start_with("U")
+      expect(shorthand_for(race: "WHITE")).to start_with("W")
+    end
+
+    it "has a letter for gender in the second position" do
+      expect(shorthand_for(sex: "Male")[1]).to eq("M")
+      expect(shorthand_for(sex: "Female")[1]).to eq("F")
+    end
+
+    it "uses a character for other gender"
+
+    it "Formats the height in feet and inches" do
+      expect(shorthand_for(height_in_inches: 70)).to include("5'10\"")
+    end
+
+    it "includes the weight in pounds" do
+      expect(shorthand_for(weight_in_pounds: 180)).to include("180 lb")
+    end
+
+    it "gracefully handles missing information" do
+      expect(shorthand_for(height_in_inches: nil).chars.count("–")).to eq(1)
+      expect(shorthand_for(weight_in_pounds: nil).chars.count("–")).to eq(1)
+      expect(shorthand_for(height_in_inches: nil, weight_in_pounds: nil)).
+        not_to include("–")
+    end
+
+    def shorthand_for(person_attrs)
+      build(:person, person_attrs).shorthand_description
+    end
+  end
+end

--- a/spec/models/response_plan_spec.rb
+++ b/spec/models/response_plan_spec.rb
@@ -2,25 +2,7 @@ require "rails_helper"
 require "shared/analytics_token"
 
 RSpec.describe ResponsePlan, type: :model do
-  it_should_behave_like "it has an analytics token"
-
   describe "validations" do
-    it { should allow_value("Female").for(:sex) }
-    it { should allow_value("Male").for(:sex) }
-    it { should allow_value(nil).for(:sex) }
-    it { should_not allow_value("FEMALE").for(:sex) }
-    it { should_not allow_value("M").for(:sex) }
-
-    it { should allow_value("AFRICAN AMERICAN/BLACK").for(:race) }
-    it { should allow_value("AMERICAN INDIAN/ALASKAN NATIVE").for(:race) }
-    it { should allow_value("ASIAN (ALL)/PACIFIC ISLANDER").for(:race) }
-    it { should allow_value("UNKNOWN").for(:race) }
-    it { should allow_value("WHITE").for(:race) }
-    it { should allow_value(nil).for(:race) }
-    it { should_not allow_value("BLACK").for(:race) }
-    it { should_not allow_value("W").for(:race) }
-    it { should_not allow_value("White").for(:race) }
-
     it "does not allow the same officer to both author and approve" do
       officer = build(:officer)
       response_plan = build(:response_plan, author: officer, approver: officer)
@@ -56,6 +38,7 @@ RSpec.describe ResponsePlan, type: :model do
     it { should have_many(:response_strategies).dependent(:destroy) }
     it { should belong_to(:author) }
     it { should belong_to(:approver) }
+    it { should belong_to(:person) }
   end
 
   describe "#alias_list=" do
@@ -143,14 +126,6 @@ RSpec.describe ResponsePlan, type: :model do
     end
   end
 
-  describe "#display_name" do
-    it "displays last name, first name" do
-      response_plan = build(:response_plan, first_name: "John", last_name: "Doe")
-
-      expect(response_plan.display_name).to eq("Doe, John")
-    end
-  end
-
   describe "#profile_image_url" do
     context "when no image is uploaded" do
       it "returns a URL to the default profile image" do
@@ -158,42 +133,6 @@ RSpec.describe ResponsePlan, type: :model do
 
         expect(response_plan.profile_image_url).to eq("/assets/default_image.png")
       end
-    end
-  end
-
-  describe "#shorthand_description" do
-    it "starts with a letter representing race" do
-      expect(shorthand_for(race: "AFRICAN AMERICAN/BLACK")).to start_with("B")
-      expect(shorthand_for(race: "AMERICAN INDIAN/ALASKAN NATIVE")).to start_with("I")
-      expect(shorthand_for(race: "ASIAN (ALL)/PACIFIC ISLANDER")).to start_with("A")
-      expect(shorthand_for(race: "UNKNOWN")).to start_with("U")
-      expect(shorthand_for(race: "WHITE")).to start_with("W")
-    end
-
-    it "has a letter for gender in the second position" do
-      expect(shorthand_for(sex: "Male")[1]).to eq("M")
-      expect(shorthand_for(sex: "Female")[1]).to eq("F")
-    end
-
-    it "uses a character for other gender"
-
-    it "Formats the height in feet and inches" do
-      expect(shorthand_for(height_in_inches: 70)).to include("5'10\"")
-    end
-
-    it "includes the weight in pounds" do
-      expect(shorthand_for(weight_in_pounds: 180)).to include("180 lb")
-    end
-
-    it "gracefully handles missing information" do
-      expect(shorthand_for(height_in_inches: nil).chars.count("–")).to eq(1)
-      expect(shorthand_for(weight_in_pounds: nil).chars.count("–")).to eq(1)
-      expect(shorthand_for(height_in_inches: nil, weight_in_pounds: nil)).
-        not_to include("–")
-    end
-
-    def shorthand_for(response_plan_attrs)
-      build(:response_plan, response_plan_attrs).shorthand_description
     end
   end
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -51,192 +51,178 @@ describe Search do
   describe "#close_matches" do
     context "with no parameters" do
       it "returns all response plans" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new({}).close_matches
+        matches = Search.new({}).close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
     end
 
     describe "searching by name" do
       it "does not return records whose names do not match" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        mismatch = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "Mary").close_matches
+        matches = Search.new(name: "Mary").close_matches
 
-        expect(plans).to eq([])
+        expect(matches).to eq([])
       end
 
       it "returns records that match on first name" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "John").close_matches
+        matches = Search.new(name: "John").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "returns records that match on last name" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "Doe").close_matches
+        matches = Search.new(name: "Doe").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "returns records that match on the full name" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "John Doe").close_matches
+        matches = Search.new(name: "John Doe").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "returns records that match on the reversed name" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "Doe John").close_matches
+        matches = Search.new(name: "Doe John").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       pending "returns records that contain the searched name" do
-        name = "Christopher Nolan"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "Christopher Nolan")
 
-        plans = Search.new(name: "Chris").close_matches
+        matches = Search.new(name: "Chris").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "returns records whose first names sound similar" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "Jon").close_matches
+        matches = Search.new(name: "Jon").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "returns records whose last names sound similar" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "Doh").close_matches
+        matches = Search.new(name: "Doh").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "returns records whose full names sound similar" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "Jon Doh").close_matches
+        matches = Search.new(name: "Jon Doh").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "returns records whose reversed full names sound similar" do
-        name = "John Doe"
-        response_plan = create(:response_plan, name: name)
+        person = create(:person, name: "John Doe")
 
-        plans = Search.new(name: "Doh Jon").close_matches
+        matches = Search.new(name: "Doh Jon").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
     end
 
     describe "searching by date of birth" do
       pending "ignores dates in an unrecognized format" do
-        plan = create(:response_plan)
-        _mismatch = create(:response_plan, date_of_birth: Date.new(1978, 01, 02))
+        match = create(:person)
+        mismatch = create(:person, date_of_birth: Date.new(1978, 01, 02))
 
-        plans = Search.new(date_of_birth: "foo").close_matches
+        matches = Search.new(date_of_birth: "foo").close_matches
 
-        expect(plans).to eq([plan])
+        expect(matches).to eq([person])
       end
 
       it "parses dates in 'mm-dd-yyyy'" do
-        match = create(:response_plan, date_of_birth: Date.new(1980, 01, 02))
-        _mismatch = create(:response_plan, date_of_birth: Date.new(1978, 01, 02))
+        match = create(:person, date_of_birth: Date.new(1980, 01, 02))
+        mismatch = create(:person, date_of_birth: Date.new(1978, 01, 02))
 
-        plans = Search.new(date_of_birth: "01-02-1980").close_matches
+        matches = Search.new(date_of_birth: "01-02-1980").close_matches
 
-        expect(plans).to eq([match])
+        expect(matches).to eq([match])
       end
 
       it "returns records whose DOBs are a year earlier" do
-        match = create(:response_plan, date_of_birth: Date.new(1980, 01, 02))
+        match = create(:person, date_of_birth: Date.new(1980, 01, 02))
 
-        plans = Search.new(date_of_birth: "01-02-1981").close_matches
+        matches = Search.new(date_of_birth: "01-02-1981").close_matches
 
-        expect(plans).to eq([match])
+        expect(matches).to eq([match])
       end
 
       it "returns records whose DOBs are a year later" do
-        match = create(:response_plan, date_of_birth: Date.new(1980, 01, 02))
+        match = create(:person, date_of_birth: Date.new(1980, 01, 02))
 
-        plans = Search.new(date_of_birth: "01-02-1979").close_matches
+        matches = Search.new(date_of_birth: "01-02-1979").close_matches
 
-        expect(plans).to eq([match])
+        expect(matches).to eq([match])
       end
 
       it "returns records whose DOBs are within a year" do
-        match = create(:response_plan, date_of_birth: Date.new(1980, 01, 02))
+        match = create(:person, date_of_birth: Date.new(1980, 01, 02))
 
-        plans = Search.new(date_of_birth: "05-02-1980").close_matches
+        matches = Search.new(date_of_birth: "05-02-1980").close_matches
 
-        expect(plans).to eq([match])
+        expect(matches).to eq([match])
       end
     end
 
     describe "searching by name and DOB" do
       it "returns exact matches for name and DOB" do
-        name = "John Doe"
         dob = Date.new(1980, 01, 02)
-        response_plan = create(:response_plan, name: name, date_of_birth: dob)
+        person = create(:person, name: "John Doe", date_of_birth: dob)
 
-        plans = Search.new(name: "Doe John", date_of_birth: "01-02-1980").close_matches
+        matches = Search.new(name: "Doe John", date_of_birth: "01-02-1980").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "returns records whose name and DOB are slightly off" do
-        name = "John Doe"
         dob = Date.new(1980, 01, 02)
-        response_plan = create(:response_plan, name: name, date_of_birth: dob)
+        person = create(:person, name: "John Doe", date_of_birth: dob)
 
-        plans = Search.new(name: "Jon Doh", date_of_birth: "01-02-1981").close_matches
+        matches = Search.new(name: "Jon Doh", date_of_birth: "01-02-1981").close_matches
 
-        expect(plans).to eq([response_plan])
+        expect(matches).to eq([person])
       end
 
       it "does not return records whose name matches, and DOB doesn't" do
-        response_plan = create(
-          :response_plan,
+        person = create(
+          :person,
           name: "John Doe",
           date_of_birth: Date.new(1980, 01, 02),
         )
 
-        plans = Search.new(name: "Jon Doh", date_of_birth: "01-02-1985").close_matches
+        matches = Search.new(name: "Jon Doh", date_of_birth: "01-02-1985").close_matches
 
-        expect(plans).to eq([])
+        expect(matches).to eq([])
       end
 
       it "does not return records whose DOB matches, and name doesn't" do
-        name = "John Doe"
         dob = Date.new(1980, 01, 02)
-        response_plan = create(:response_plan, name: name, date_of_birth: dob)
+        mismatch = create(:person, name: "John Doe", date_of_birth: dob)
 
-        plans = Search.new(name: "Mary", date_of_birth: "01-02-1980").close_matches
+        matches = Search.new(name: "Mary", date_of_birth: "01-02-1980").close_matches
 
-        expect(plans).to eq([])
+        expect(matches).to eq([])
       end
     end
   end


### PR DESCRIPTION
## Problem

When a response plan is updated,
we need to be able to show the previous version of the plan
while the new version is pending approval.

The first step is extracting a `Person` model out of
`ResponsePlan`, to hold the person's physical characteristics and other
information that doesn't change between versions of a response plan.

This will also let us track versions of response plan information,
which will help us comply with public disclosure requests and the legal
auditing requirements of the Police Department.
