### PR TITLE
Recognize super old dates of birth

### DIFF
--- a/app/assets/javascripts/application/date_of_birth.js
+++ b/app/assets/javascripts/application/date_of_birth.js
@@ -1,6 +1,6 @@
 $(function(){
    $("#search_date_of_birth").mask("99-99-9999", {
-     placeholder: "mm-dd-yyyy",
+     placeholder: "__-__-____",
      autoclear: false
    });
 });

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -80,6 +80,12 @@
 
       input {
         @include span-columns(6 of 8);
+        float: none;
+      }
+
+      .error {
+        @include span-columns(6 of 8);
+        float: right;
       }
 
       .input {

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -118,9 +118,7 @@ class Search
   end
 
   def parse_date_of_birth
-    attempted_parse = Date.strptime(@date_of_birth, "%m-%d-%Y")
-    feasible = (120.years.ago.to_date..Date.today).cover?(attempted_parse)
-    @date_of_birth = feasible ? attempted_parse : nil
+    @date_of_birth = Date.strptime(@date_of_birth, "%m-%d-%Y")
   rescue ArgumentError
     @invalid_date = true
     @date_of_birth = nil


### PR DESCRIPTION
## Problem

When an officer entered a date of birth over 120 years ago,
a bug caused it to be ignored without showing an error.
This is a bit disconcerting for officers,
who don't have a chance to see the error.
## Solution

Accept all dates for DOB search,
even if they're unfeasably old.

Also, fix formatting of DOB error message.
