### PR TITLE
Move aliases from `ResponsePlan` to `Person`

### DIFF
--- a/app/controllers/response_plans_controller.rb
+++ b/app/controllers/response_plans_controller.rb
@@ -53,7 +53,6 @@ class ResponsePlansController < ApplicationController
 
     @response_plan = original.deep_clone(
       include: [
-        :aliases,
         :contacts,
         :response_strategies,
         :safety_concerns,
@@ -117,11 +116,6 @@ class ResponsePlansController < ApplicationController
     params.require(:response_plan).permit(
       :background_info,
       :private_notes,
-      aliases_attributes: [
-        :_destroy,
-        :id,
-        :name,
-      ],
       contacts_attributes: [
         :_destroy,
         :cell,
@@ -130,11 +124,6 @@ class ResponsePlansController < ApplicationController
         :notes,
         :organization,
         :relationship,
-      ],
-      images_attributes: [
-        :_destroy,
-        :id,
-        :source,
       ],
       person_attributes: [
         :date_of_birth,
@@ -150,6 +139,16 @@ class ResponsePlansController < ApplicationController
         :scars_and_marks,
         :sex,
         :weight_in_pounds,
+        aliases_attributes: [
+          :_destroy,
+          :id,
+          :name,
+        ],
+        images_attributes: [
+          :_destroy,
+          :id,
+          :source,
+        ],
       ],
       response_strategies_attributes: [
         :_destroy,

--- a/app/models/alias.rb
+++ b/app/models/alias.rb
@@ -1,8 +1,8 @@
 class Alias < ActiveRecord::Base
-  belongs_to :response_plan
+  belongs_to :person
 
-  validates :response_plan, presence: true
+  validates :person, presence: true
   validates :name,
     presence: true,
-    uniqueness: { scope: :response_plan_id }
+    uniqueness: { scope: :person_id }
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -39,8 +39,9 @@ class Person < ActiveRecord::Base
     :red,
   ].freeze
 
-  has_many :response_plans
+  has_many :aliases, dependent: :destroy
   has_many :images, dependent: :destroy
+  has_many :response_plans
 
   validates :sex, inclusion: SEX_CODES.keys, allow_nil: true
   validates :race, inclusion: RACE_CODES.keys, allow_nil: true
@@ -54,6 +55,11 @@ class Person < ActiveRecord::Base
     using: [:tsearch, :dmetaphone, :trigram],
   )
 
+  accepts_nested_attributes_for(
+    :aliases,
+    reject_if: :all_blank,
+    allow_destroy: true,
+  )
   accepts_nested_attributes_for(
     :images,
     reject_if: :all_blank,

--- a/app/models/response_plan.rb
+++ b/app/models/response_plan.rb
@@ -1,18 +1,12 @@
 class ResponsePlan < ActiveRecord::Base
   belongs_to :person
 
-  has_many :aliases, dependent: :destroy
   has_many :contacts, dependent: :destroy
   has_many :response_strategies, -> { order(:priority) }, dependent: :destroy
   has_many :safety_concerns, dependent: :destroy
 
   accepts_nested_attributes_for(:person)
 
-  accepts_nested_attributes_for(
-    :aliases,
-    reject_if: :all_blank,
-    allow_destroy: true,
-  )
   accepts_nested_attributes_for(
     :contacts,
     reject_if: :all_blank,
@@ -43,18 +37,6 @@ class ResponsePlan < ActiveRecord::Base
 
   validates :person, presence: true
   validate :errors_from_associated_person
-
-  def alias_list=(list_of_aliases)
-    alias_objects = list_of_aliases.map do |aka|
-      Alias.find_or_initialize_by(name: aka, response_plan: self)
-    end
-
-    self.aliases = alias_objects
-  end
-
-  def alias_list
-    aliases.pluck(:name)
-  end
 
   def approved?
     approved_at.present? &&

--- a/app/views/response_plans/_form.html.erb
+++ b/app/views/response_plans/_form.html.erb
@@ -4,11 +4,8 @@
       <%= person.input :first_name %>
       <%= person.input :last_name %>
       <%= person.input :date_of_birth, label: "DOB", as: :string %>
-    <% end %>
+      <%= render "nested_form", f: person, relationship: :aliases, html_classes: [] %>
 
-    <%= render "nested_form", f: f, relationship: :aliases, html_classes: [] %>
-
-    <%= f.fields_for :person do |person| %>
       <%= person.input :race, collection: Person::RACE_CODES.keys %>
       <%= person.input :sex, collection: Person::SEX_CODES.keys %>
       <%= person.input :weight_in_pounds, label: "Weight" %>

--- a/app/views/sections/_profile.html.erb
+++ b/app/views/sections/_profile.html.erb
@@ -4,12 +4,12 @@
 
     <hr/>
 
-    <% if response_plan.aliases.any? %>
+    <% if response_plan.person.aliases.any? %>
       <div class="aliases">
         <h3>AKA</h3>
 
         <ul>
-          <% response_plan.aliases.each do |aka| %>
+          <% response_plan.person.aliases.each do |aka| %>
             <li><%= aka.name %></li>
           <% end %>
         </ul>

--- a/db/migrate/20160729011351_move_aliases_to_people.rb
+++ b/db/migrate/20160729011351_move_aliases_to_people.rb
@@ -1,0 +1,43 @@
+class MoveAliasesToPeople < ActiveRecord::Migration
+  def up
+    change_table :aliases do |t|
+      t.belongs_to :person, index: true, foreign_key: true
+    end
+
+    execute(<<-SQL)
+    UPDATE aliases
+    SET person_id = (
+      SELECT person_id
+      FROM response_plans
+      WHERE response_plans.id = aliases.response_plan_id
+    )
+    SQL
+
+    change_column_null :aliases, :person_id, false
+
+    change_table :aliases do |t|
+      t.remove :response_plan_id
+    end
+  end
+
+  def down
+    change_table :aliases do |t|
+      t.belongs_to :response_plan, index: true, foreign_key: true
+    end
+
+    execute(<<-SQL)
+    UPDATE aliases
+    SET response_plan_id = (
+      SELECT id
+      FROM response_plans
+      WHERE response_plans.person_id = aliases.person_id
+      ORDER BY approved_at DESC
+      LIMIT 1
+    )
+    SQL
+
+    change_table :aliases do |t|
+      t.remove :person_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160726054237) do
+ActiveRecord::Schema.define(version: 20160729011351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,13 +19,13 @@ ActiveRecord::Schema.define(version: 20160726054237) do
   enable_extension "fuzzystrmatch"
 
   create_table "aliases", force: :cascade do |t|
-    t.integer  "response_plan_id"
-    t.string   "name",             null: false
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer  "person_id",  null: false
   end
 
-  add_index "aliases", ["response_plan_id"], name: "index_aliases_on_response_plan_id", using: :btree
+  add_index "aliases", ["person_id"], name: "index_aliases_on_person_id", using: :btree
 
   create_table "contacts", force: :cascade do |t|
     t.integer  "response_plan_id"
@@ -140,7 +140,7 @@ ActiveRecord::Schema.define(version: 20160726054237) do
 
   add_index "safety_concerns", ["response_plan_id"], name: "index_safety_concerns_on_response_plan_id", using: :btree
 
-  add_foreign_key "aliases", "response_plans"
+  add_foreign_key "aliases", "people"
   add_foreign_key "contacts", "response_plans"
   add_foreign_key "images", "people"
   add_foreign_key "response_plans", "people"

--- a/spec/controllers/response_plans_controller_spec.rb
+++ b/spec/controllers/response_plans_controller_spec.rb
@@ -92,18 +92,6 @@ RSpec.describe ResponsePlansController, type: :controller do
       expect(clone).not_to be_persisted
     end
 
-    it "copies over aliases" do
-      officer = create(:officer, username: "admin")
-      stub_admin_permissions(officer)
-      original = create(:alias, name: "Bob")
-
-      get :edit, { id: original.response_plan.id }, { officer_id: officer.id }
-
-      clone = assigns(:response_plan).aliases.first
-      expect(clone.name).to eq(original.name)
-      expect(clone).not_to be_persisted
-    end
-
     it "copies over response_strategies" do
       officer = create(:officer, username: "admin")
       stub_admin_permissions(officer)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :alias do
     name "John Doe"
-    response_plan
+    person
   end
 
   factory :contact do
@@ -42,7 +42,6 @@ FactoryGirl.define do
 
   factory :response_plan do
     person
-    aliases []
     author
     approver
     updated_at { 1.second.ago }

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -69,7 +69,8 @@ feature "Officer views a response plan" do
     sign_in_officer
     aliases = ["Mark Smith", "Joe Andrews"]
     person = create(:person, name: "John Doe")
-    response_plan = create(:response_plan, alias_list: aliases, person: person)
+    response_plan = create(:response_plan, person: person)
+    aliases.each { |aka| create(:alias, name: aka, person: person) }
 
     visit response_plan_path(response_plan)
 

--- a/spec/features/response_plan_form_spec.rb
+++ b/spec/features/response_plan_form_spec.rb
@@ -125,7 +125,8 @@ feature "Response Plan Form" do
       admin_officer = create(:officer, username: "admin")
       sign_in_officer(admin_officer)
       stub_admin_permissions(admin_officer)
-      plan = create(:response_plan, alias_list: ["Foo"])
+      plan = create(:response_plan)
+      create(:alias, name: "Foo", person: plan.person)
 
       visit edit_response_plan_path(plan)
       click_on "remove alias"

--- a/spec/models/alias_spec.rb
+++ b/spec/models/alias_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Alias, type: :model do
   describe "validations" do
-    it { should validate_presence_of(:response_plan) }
+    it { should validate_presence_of(:person) }
     it { should validate_presence_of(:name) }
 
     context "uniqueness" do
       subject { build(:alias) }
 
-      it { should validate_uniqueness_of(:name).scoped_to(:response_plan_id) }
+      it { should validate_uniqueness_of(:name).scoped_to(:person_id) }
     end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Person, type: :model do
 
   describe "associations" do
     it { should have_many(:response_plans) }
+    it { should have_many(:aliases).dependent(:destroy) }
+    it { should have_many(:images).dependent(:destroy) }
   end
 
   describe "validations" do

--- a/spec/models/response_plan_spec.rb
+++ b/spec/models/response_plan_spec.rb
@@ -33,24 +33,11 @@ RSpec.describe ResponsePlan, type: :model do
 
   describe "associations" do
     it { should have_many(:safety_concerns).dependent(:destroy) }
-    it { should have_many(:aliases).dependent(:destroy) }
     it { should have_many(:contacts).dependent(:destroy) }
     it { should have_many(:response_strategies).dependent(:destroy) }
     it { should belong_to(:author) }
     it { should belong_to(:approver) }
     it { should belong_to(:person) }
-  end
-
-  describe "#alias_list=" do
-    it "destroys the associated alias object when it gets overwritten" do
-      plan = create(:response_plan, alias_list: ["foo"])
-
-      plan.alias_list = ["bar"]
-      plan.save
-
-      expect(Alias.find_by(name: "foo")).to be_nil
-      expect(Alias.find_by(name: "bar")).to be_persisted
-    end
   end
 
   describe "#approved?" do


### PR DESCRIPTION
## Problem

We will be pulling aliases from another system,
and they will not generally change for a person
from plan to plan.
## Solution

Change the association for aliases to tie them to people
instead of response plans.
