### PR TITLE
Revert "no officer safety" message to v0.1.4

### DIFF
--- a/app/assets/stylesheets/response_plan/_safety_concerns.scss
+++ b/app/assets/stylesheets/response_plan/_safety_concerns.scss
@@ -1,4 +1,8 @@
 .safety-concerns {
+  .section-header {
+    background-color: $safety-section-header-background;
+  }
+
   .safety-concern-icons {
     @include span-columns(1 of 8);
     text-align: center;

--- a/app/views/sections/_safety_concerns.html.erb
+++ b/app/views/sections/_safety_concerns.html.erb
@@ -30,7 +30,12 @@
         </div>
       <% end %>
     <% else %>
-      <%= t("response_plans.safety.none") %>
+      <p>Officer safety information is still under development.</p>
+
+      <p>
+      For information about <%= @response_plan.person.first_name %>,
+      please see the <strong>Response Plan</strong> section below.
+      </p>
     <% end %>
   </div>
 </section>

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -192,7 +192,7 @@ feature "Officer views a response plan" do
   end
 
   context "when there are no safety concerns" do
-    scenario "they see a note saying there are no concerns" do
+    pending "they see a note saying there are no concerns" do
       sign_in_officer
       response_plan = create(:response_plan)
 


### PR DESCRIPTION
## Problem

We want to do a slow rollout of officer safety concerns,
to allow us to add officer safety concerns to the app
before officers become dependent on having accurate information present.
## Solution

If there are no officer safety concerns for an individual,
continue displaying a message
saying that the feature is not implemented.

When we start to fill out officer safety concerns,
officers will see them gradually appear in the app.
At that point, we can switch the messaging
to more accurately reflect the feature's implementation status.
