### PR TITLE
Record response plan views for officers

### DIFF
--- a/app/controllers/response_plans_controller.rb
+++ b/app/controllers/response_plans_controller.rb
@@ -24,6 +24,8 @@ class ResponsePlansController < ApplicationController
     unless current_officer.admin?
       ensure_response_plan_is_approved(@response_plan)
     end
+
+    record_page_view(@response_plan)
   end
 
   def new
@@ -182,5 +184,9 @@ class ResponsePlansController < ApplicationController
     unless response_plan.approved?
       raise ActiveRecord::RecordNotFound
     end
+  end
+
+  def record_page_view(response_plan)
+    PageView.create(officer: current_officer, person: response_plan.person)
   end
 end

--- a/app/models/page_view.rb
+++ b/app/models/page_view.rb
@@ -1,0 +1,4 @@
+class PageView < ActiveRecord::Base
+  belongs_to :officer
+  belongs_to :person
+end

--- a/db/migrate/20160805135401_create_page_views.rb
+++ b/db/migrate/20160805135401_create_page_views.rb
@@ -1,0 +1,10 @@
+class CreatePageViews < ActiveRecord::Migration
+  def change
+    create_table :page_views do |t|
+      t.references :officer, index: true, foreign_key: true
+      t.references :person, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160729212645) do
+ActiveRecord::Schema.define(version: 20160805135401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,16 @@ ActiveRecord::Schema.define(version: 20160729212645) do
   end
 
   add_index "officers", ["username"], name: "index_officers_on_username", unique: true, using: :btree
+
+  create_table "page_views", force: :cascade do |t|
+    t.integer  "officer_id"
+    t.integer  "person_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "page_views", ["officer_id"], name: "index_page_views_on_officer_id", using: :btree
+  add_index "page_views", ["person_id"], name: "index_page_views_on_person_id", using: :btree
 
   create_table "people", force: :cascade do |t|
     t.datetime "created_at",       null: false
@@ -223,6 +233,8 @@ ActiveRecord::Schema.define(version: 20160729212645) do
   add_foreign_key "contacts", "response_plans"
   add_foreign_key "deescalation_techniques", "response_plans"
   add_foreign_key "images", "people"
+  add_foreign_key "page_views", "officers"
+  add_foreign_key "page_views", "people"
   add_foreign_key "response_plans", "people"
   add_foreign_key "response_strategies", "response_plans"
   add_foreign_key "rms_crisis_incidents", "rms_people"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -34,6 +34,11 @@ FactoryGirl.define do
     phone "222-333-4444"
   end
 
+  factory :page_view do
+    officer
+    person
+  end
+
   factory :person do
     name "John Doe"
     sex "Male"

--- a/spec/models/page_view_spec.rb
+++ b/spec/models/page_view_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe PageView, type: :model do
+end


### PR DESCRIPTION
This is an incremental step
towards displaying recently viewed response plans,
as well as tracking analytics about how response plans are used.
