### PR TITLE
Implement searching by alias

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -53,8 +53,15 @@ class Person < ActiveRecord::Base
   pg_search_scope(
     :search,
     against: [:first_name, :last_name],
-    associated_against: { rms_person: [:first_name, :last_name] },
-    using: [:tsearch, :dmetaphone, :trigram],
+    associated_against: {
+      aliases: [:name],
+      rms_person: [:first_name, :last_name],
+    },
+    using: {
+      dmetaphone: {},
+      trigram: { threshold: 0.2 },
+      tsearch: {},
+    },
   )
 
   accepts_nested_attributes_for(

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -35,7 +35,8 @@ class Search
   end
 
   def close_matches
-    people = Person.joins("LEFT OUTER JOIN rms_people ON rms_people.person_id = people.id")
+    people = Person.
+      joins("LEFT OUTER JOIN rms_people ON rms_people.person_id = people.id")
 
     if name.present?
       people = people.search(name)

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -92,6 +92,15 @@ describe Search do
         expect(matches).to eq([person])
       end
 
+      it "returns records that match on alias" do
+        person = create(:person, name: "Foo Bar")
+        create(:alias, person: person, name: "Buddy")
+
+        matches = Search.new(name: "Bud").close_matches
+
+        expect(matches).to eq([person])
+      end
+
       it "returns records that match on the reversed name" do
         person = create(:person, name: "John Doe")
 
@@ -100,7 +109,7 @@ describe Search do
         expect(matches).to eq([person])
       end
 
-      pending "returns records that contain the searched name" do
+      it "returns records that contain the searched name" do
         person = create(:person, name: "Christopher Nolan")
 
         matches = Search.new(name: "Chris").close_matches
@@ -154,13 +163,12 @@ describe Search do
     end
 
     describe "searching by date of birth" do
-      pending "ignores dates in an unrecognized format" do
-        match = create(:person)
-        mismatch = create(:person, date_of_birth: Date.new(1978, 01, 02))
+      it "ignores dates in an unrecognized format" do
+        match = create(:person, date_of_birth: Date.new(1978, 01, 02))
 
         matches = Search.new(date_of_birth: "foo").close_matches
 
-        expect(matches).to eq([person])
+        expect(matches).to eq([match])
       end
 
       it "parses dates in 'mm-dd-yyyy'" do


### PR DESCRIPTION
## Problem

Often, individuals give officers fake names
that can make it difficult for the officer to identify the person.
These names are often consistent for an individual;
they'll give the same name to an officer on multiple interactions,
and they're recorded in the RMS and our system as aliases.
## Solution

When an officer searches for a name,
include search results for people
with aliases that match the search term.
