### PR TITLE
Make changing themes more consistent

### DIFF
--- a/app/assets/javascripts/application/header.js
+++ b/app/assets/javascripts/application/header.js
@@ -2,20 +2,4 @@ $(function() {
   $("#js-toggle-menu").on("click", function() {
     $("body").toggleClass("menu-active");
   });
-
-  $(".change-theme").on("click", function() {
-    $.post("/preferences");
-
-    var stylesheet = $(".theme-stylesheet");
-    var originalLink = stylesheet.attr("href");
-
-    stylesheet.attr("href", stylesheet.data("alternate"));
-    stylesheet.data("alternate", originalLink);
-
-    var inactive_theme = $(".change-theme-toggle .theme:not(.selected)");
-    $(".change-theme-toggle .theme").removeClass("selected");
-    inactive_theme.addClass("selected");
-
-    return false;
-  });
 });

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  helper_method :theme, :inactive_theme, :officer_signed_in?, :current_officer
+  helper_method :theme, :officer_signed_in?, :current_officer
 
   def authenticate_officer!
     unless officer_signed_in?
@@ -33,19 +33,5 @@ class ApplicationController < ActionController::Base
 
   def theme
     session[:theme] || :day
-  end
-
-  def inactive_theme
-    toggle(:day, :night, theme)
-  end
-
-  private
-
-  def toggle(first, second, current)
-    {
-      first => second,
-      second => first,
-      nil => second,
-    }.with_indifferent_access[current]
   end
 end

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -3,4 +3,18 @@ class PreferencesController < ApplicationController
     session[:theme] = inactive_theme
     redirect_to :back
   end
+
+  private
+
+  def inactive_theme
+    toggle(:day, :night, theme)
+  end
+
+  def toggle(first, second, current)
+    {
+      first => second,
+      second => first,
+      nil => second,
+    }.with_indifferent_access[current]
+  end
 end

--- a/app/views/application/_menu.html.erb
+++ b/app/views/application/_menu.html.erb
@@ -1,10 +1,10 @@
 <div class="menu">
-  <a class="change-theme" role="link">
+  <%= link_to preferences_path, method: :post, class: "change-theme" do %>
     <div class="change-theme-toggle">
       <span class="theme day-theme <%= "selected" if theme == "day" %>">Light</span>
       <span class="theme night-theme <%= "selected" if theme == "night" %>">Dark</span>
     </div>
-  </a>
+  <% end %>
 
   <%= link_to("About", page_path("about")) %>
   <%= link_to("App Updates", page_path("changelog")) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,20 +8,7 @@
 
   <title><%= title %></title>
 
-  <%= stylesheet_link_tag(
-    theme,
-    media: "all",
-    class: "theme-stylesheet",
-    data: { alternate: stylesheet_path(inactive_theme) }
-  ) %>
-  <style>
-.change-theme-toggle .theme {
-  transition-property: background-color, color;
-  transition-duration: 150ms;
-  transition-timing-function: ease;
-  transition-delay: initial;
-}
-  </style>
+  <%= stylesheet_link_tag(theme, media: "all") %>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600" rel="stylesheet">
   <link rel="stylesheet" href="/assets/print.css" media="print" />
   <%= csrf_meta_tags %>

--- a/spec/features/night_mode_spec.rb
+++ b/spec/features/night_mode_spec.rb
@@ -10,15 +10,10 @@ feature "Night mode" do
   end
 
   scenario "Officer switches to night mode", :js do
-    pending "
-    This must be tested in Javascript,
-    because it appears that Poltergeist does not support
-    swapping out CSS link tag `href` attributes."
-
     visit new_authentication_path
 
-    find(".menu-icon").click
-    find(".change-theme").trigger('click')
+    find(".menu-icon").trigger('click')
+    find(".change-theme").click
 
     header_color = get_header_background_color
     expect(header_color).to eq("rgb(33, 33, 33)")

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
 
 RSpec.describe FeedbackMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe Image, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
## Problem

With our fancy footwork for switching themes by swapping out the `href`
attribute of our `link` tags,
some officers reported that night mode would not persist
after they left the current page.
## Solution

Revert the `href`-swapping and AJAX solution for night mode,
and go back to a regular page refresh.

Officers will likely not be swapping back and forth so often
that performance is a concern.

Reverting the javascript also restores our tests to passing,
where they had previously failed because of PhantomJS' inability to swap
stylesheets on the fly.
