### PR TITLE
Hide maps behind an accordian by default

### DIFF
--- a/app/assets/javascripts/application/location.js
+++ b/app/assets/javascripts/application/location.js
@@ -47,7 +47,7 @@ function initMap() {
   });
 
   function setUpMap(location) {
-    var mapElement = $(".location-map")[0];
+    var mapElement = $(".location-map-canvas")[0];
 
     map = new google.maps.Map(mapElement, {
       center: location,
@@ -60,6 +60,10 @@ function initMap() {
       map: map,
       icon: mapMarkerIcon
     });
+
+    setTimeout(function() {
+      $(".location-map").addClass("collapsed");
+    }, 500);
 
     return map;
   }

--- a/app/assets/stylesheets/_location.scss
+++ b/app/assets/stylesheets/_location.scss
@@ -1,9 +1,5 @@
 $zoom-control-height: 1.5em;
 
-.location-map {
-  height: 12em;
-}
-
 .location-name,
 .location-address {
   display: block;
@@ -16,6 +12,10 @@ $zoom-control-height: 1.5em;
 .location-address-line-one,
 .location-address-line-two {
   display: block;
+}
+
+.location-map.collapsed {
+  display: none;
 }
 
 .map-controls {
@@ -36,4 +36,8 @@ $zoom-control-height: 1.5em;
 
 .zoom-out {
   background-image: $zoom_out_image;
+}
+
+.location-map-canvas {
+  height: 12em;
 }

--- a/app/views/sections/_location.html.erb
+++ b/app/views/sections/_location.html.erb
@@ -18,13 +18,24 @@
         <span class="location-address-line-one"></span>
         <span class="location-address-line-two"></span>
       </span>
+    </div>
 
-      <div class="map-controls">
+    <div class="location-map">
+      <div class="map-controls section-body">
         <span class="zoom zoom-out"></span>
         <span class="zoom zoom-in"></span>
       </div>
+
+      <div class="location-map-canvas"></div>
     </div>
 
-    <div class="location-map"></div>
+    <a
+      href="#"
+      class="section-body toggle"
+      data-toggle-text="Hide Map"
+      data-toggle-target=".location-map"
+      >
+      Show Map
+    </a>
   </section>
 <% end %>


### PR DESCRIPTION
## Problem

Some officers find the map completely unnecessary.
Others noted that it gets in the way of scrolling down the page,
as it intercepts scroll events and uses them for panning.
## Solution

Hide the map behind an accordian on the page by defualt.
