### PR TITLE
For now, don't show people without a response plan

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -6,7 +6,9 @@ class PeopleController < ApplicationController
     @search.validate
     people = @search.close_matches
 
-    @response_plans = people.map do |person|
+    @response_plans = people.select do |person|
+      visible_plan_for(person)
+    end.map do |person|
       [person, visible_plan_for(person)]
     end.to_h
   end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PeopleController, type: :controller do
   end
 
   describe "GET #index" do
-    it "shows people who do not have a response plan" do
+    pending "shows people who do not have a response plan" do
       officer = create(:officer)
       rms_person = create(:rms_person, first_name: "John", last_name: "Doe")
       person = rms_person.person
@@ -34,6 +34,11 @@ RSpec.describe PeopleController, type: :controller do
       alice.update(last_name: nil)
       bob = create(:person, last_name: "Bob")
 
+      # TODO these should eventually not be necessary
+      create(:response_plan, person: alice)
+      create(:response_plan, person: bob)
+      create(:response_plan, person: charlie)
+
       get :index, {}, { officer_id: officer.id }
 
       expect(assigns(:response_plans).keys).to eq([alice, bob, charlie])
@@ -49,7 +54,10 @@ RSpec.describe PeopleController, type: :controller do
 
         expect(assigns(:response_plans)).to eq(
           approved.person => approved,
-          unapproved.person => nil,
+          # TODO: For now, don't show people without a respones plan.
+          # We'll add them in once we have a plan
+          # for the basic information layout.
+          # unapproved.person => nil,
         )
       end
     end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -5,6 +5,7 @@ feature "Search" do
     sign_in_officer
     dob = Date.new(1980, 01, 02)
     person = create(:person, name: "John Doe", date_of_birth: dob)
+    create_plans_for(person)
 
     visit people_path
 
@@ -18,6 +19,7 @@ feature "Search" do
     sign_in_officer
     dob = Date.new(1980, 01, 02)
     person = create(:person, name: "John Doe", date_of_birth: dob)
+    create_plans_for(person)
 
     visit people_path
 
@@ -48,6 +50,7 @@ feature "Search" do
       match = create(:person, date_of_birth: 20.years.ago)
       close_match = create(:person, date_of_birth: 25.years.ago)
       other = create(:person, date_of_birth: 50.years.ago)
+      create_plans_for(match, close_match, other)
 
       sign_in_officer
       visit people_path
@@ -63,6 +66,7 @@ feature "Search" do
     scenario "Officer searches by gender" do
       male = create(:person, sex: "Male")
       female = create(:person, sex: "Female")
+      create_plans_for(male, female)
 
       sign_in_officer
       visit people_path
@@ -78,6 +82,7 @@ feature "Search" do
       white = create(:person, race: "WHITE")
       asian = create(:person, race: "ASIAN (ALL)/PACIFIC ISLANDER")
       other = create(:person, race: "AFRICAN AMERICAN/BLACK")
+      create_plans_for(white, asian, other)
 
       sign_in_officer
       visit people_path
@@ -95,6 +100,7 @@ feature "Search" do
       match = create(:person, weight_in_pounds: 150)
       close_match = create(:person, weight_in_pounds: 175)
       other = create(:person, weight_in_pounds: 300)
+      create_plans_for(match, close_match, other)
 
       sign_in_officer
       visit people_path
@@ -111,6 +117,7 @@ feature "Search" do
       match = create(:person, height_in_inches: 60)
       close_match = create(:person, height_in_inches: 63)
       other = create(:person, height_in_inches: 72)
+      create_plans_for(match, close_match, other)
 
       sign_in_officer
       visit people_path
@@ -128,6 +135,7 @@ feature "Search" do
       brown = create(:person, hair_color: "Brown")
       black = create(:person, hair_color: "Black")
       other = create(:person, hair_color: "Blonde")
+      create_plans_for(brown, black, other)
 
       sign_in_officer
       visit people_path
@@ -145,6 +153,7 @@ feature "Search" do
       blue = create(:person, eye_color: :blue, weight_in_pounds: 120)
       brown = create(:person, eye_color: :brown, weight_in_pounds: 130)
       other = create(:person, eye_color: :green, weight_in_pounds: 140)
+      create_plans_for(blue, brown, other)
 
       sign_in_officer
       visit people_path
@@ -167,5 +176,10 @@ feature "Search" do
     def run_search
       first(".actions input").trigger("click")
     end
+  end
+
+  # TODO remove
+  def create_plans_for(*people)
+    people.each { |p| create(:response_plan, person: p) }
   end
 end


### PR DESCRIPTION
## Problem

We'll want to add this functionality back in eventually,
but we are not ready to show people without response plans
in production just yet.
## Solution

Add a guard clause to only show people with a response plan.
