### PR TITLE
Add pagination for search results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem "sass-rails", "~> 5.0"
 gem "simple_form"
 gem "title"
 gem "uglifier"
-gem "whenever"
 
 # The released version of this library, v1.4.1,
 # contains a bug on Android devices that causes input to be displayed backwards.

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "deep_cloneable"
 gem "delayed_job_active_record"
 gem "flutie"
 gem "high_voltage"
+gem "kaminari"
 gem "neat", "~> 1.7.0"
 gem "net-ldap"
 gem "newrelic_rpm", ">= 3.9.8"
@@ -38,6 +39,9 @@ gem "uglifier"
 # vendor/assets/javascripts/jquery.maskedinput.js
 # Once the fix is included in a new release (likely in version 1.4.2),
 # then we'll be able to load the asset through this Gemfile once again.
+#
+# To check the current version number,
+# see https://rails-assets.org/#/components/jquery.maskedinput
 #
 # gem "rails-assets-jquery.maskedinput", source: "https://rails-assets.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,9 @@ GEM
     high_voltage (2.4.0)
     i18n (0.7.0)
     json (1.8.3)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     loofah (2.0.3)
@@ -282,6 +285,7 @@ DEPENDENCIES
   flutie
   formulaic
   high_voltage
+  kaminari
   launchy
   neat (~> 1.7.0)
   net-ldap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,6 @@ GEM
       activesupport (>= 3.2.0)
       json (>= 1.7)
       mime-types (>= 1.16)
-    chronic (0.10.2)
     cliver (0.3.2)
     cocoon (1.2.9)
     coderay (1.1.0)
@@ -261,8 +260,6 @@ GEM
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    whenever (0.9.7)
-      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -317,7 +314,6 @@ DEPENDENCIES
   uglifier
   web-console
   webmock
-  whenever
 
 RUBY VERSION
    ruby 2.3.0p0

--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -19,6 +19,7 @@
 @import "layout";
 @import "location";
 @import "menu";
+@import "pagination";
 @import "recently_viewed";
 @import "response_plan_form";
 @import "response_plans";

--- a/app/assets/stylesheets/_pagination.scss
+++ b/app/assets/stylesheets/_pagination.scss
@@ -1,0 +1,9 @@
+.pagination {
+  @include span-columns(12 of 12);
+  margin-bottom: $base-spacing;
+  text-align: center;
+
+  span {
+    margin: 0 $small-spacing;
+  }
+}

--- a/app/models/officer.rb
+++ b/app/models/officer.rb
@@ -15,13 +15,23 @@ class Officer < ActiveRecord::Base
     dependent: :destroy
 
   def admin?
-    ENV.fetch("ADMIN_USERNAMES").to_s.split(",").include?(username)
+    username_defined_in_env_variable?("ADMIN_USERNAMES")
   end
 
   # TODO temporary feature flag
   # This should be removed when we allow all officers
   # to view people without response plans.
   def can_view_people_without_response_plans?
-    ENV.fetch("CAN_VIEW_WITHOUT_RESPONSE_PLANS").to_s.split(",").include?(username)
+    username_defined_in_env_variable?("CAN_VIEW_WITHOUT_RESPONSE_PLANS")
+  end
+
+  private
+
+  def username_defined_in_env_variable?(env_var)
+    ENV.fetch(env_var).
+      to_s.
+      gsub(/["']/, "").
+      split(",").
+      include?(username)
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -17,8 +17,10 @@ class Search
 
   attr_accessor(*SEARCHABLE_ATTRS)
 
-  def initialize(*args)
-    super(*args)
+  def initialize(attributes = {}, candidates = Person.all)
+    super(attributes)
+
+    @candidates = candidates
 
     if @date_of_birth.present?
       parse_date_of_birth
@@ -36,7 +38,7 @@ class Search
   end
 
   def close_matches
-    people = Person.
+    people = @candidates.
       joins("LEFT OUTER JOIN rms_people ON rms_people.person_id = people.id")
 
     if name.present?

--- a/app/views/people/_recently_viewed.html.erb
+++ b/app/views/people/_recently_viewed.html.erb
@@ -3,7 +3,8 @@
 
   <% @response_plans.each do |person, response_plan| %>
     <%= link_to person_path(person), class: "recently-viewed-plan" do %>
-      <% unless response_plan && response_plan.approved? %>
+
+      <% if response_plan && !response_plan.approved? %>
         <span class="needs-approval-banner">Needs Approval</span>
       <% end %>
 

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -9,3 +9,5 @@
 <% else %>
   <%= render "recently_viewed" %>
 <% end %>
+
+<%= paginate @people %>

--- a/spec/models/officer_spec.rb
+++ b/spec/models/officer_spec.rb
@@ -21,5 +21,17 @@ RSpec.describe Officer, type: :model do
       expect(admin).to be_admin
       expect(non_admin).not_to be_admin
     end
+
+    it "can handle quotes in the env variable" do
+      allow(ENV).to receive(:fetch).
+        with("ADMIN_USERNAMES").
+        and_return('"foo,bar"')
+
+      admin = build(:officer, username: "foo")
+      non_admin = build(:officer, username: "other")
+
+      expect(admin).to be_admin
+      expect(non_admin).not_to be_admin
+    end
   end
 end


### PR DESCRIPTION
## Problem:

Once we import peoples' information,
there are too many people to reasonably display on a single page.
Rendering the page alone starts to take on the order of minutes.
## Solution:

Paginate the people in our app,
both when the officers search and when they don't.

See https://github.com/amatsuda/kaminari
