### PR TITLE
Fix database URL for CircleCI builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 machine:
   environment:
+    DB_HOST: localhost
     LD_LIBRARY_PATH: $HOME/$CIRCLE_PROJECT_REPONAME/dependencies/instantclient_11_2
 dependencies:
   pre:


### PR DESCRIPTION
## Problem

Docker requires the `DB_HOST` environment variable to be `db`,
while CircleCI requires it to be `localhost`.

Commit e6bb4d2 moved the DB_HOST environment variable
from `docker-compose.production` to `.env`.
This process changed the variable's value to `db`
for both the Docker and CircleCI environments,
which breaks breaks the CircleCI builds.
## Solution

Override the `DB_HOST` variable for CIRCLECI only.
