### PR TITLE
Add admin links to drafts and submissions pages

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,7 +7,7 @@ class PeopleController < ApplicationController
     if current_officer.can_view_people_without_response_plans?
       @search = Search.new(search_params)
     else
-      plans = current_officer.admin? ? ResponsePlan : ResponsePlan.where.not(approved_at: nil)
+      plans = ResponsePlan.where.not(approved_at: nil)
       people_with_response_plans = Person.where(id: plans.pluck(:person_id).uniq)
       @search = Search.new(search_params, people_with_response_plans)
     end
@@ -55,11 +55,6 @@ class PeopleController < ApplicationController
   end
 
   def visible_plan_for(person)
-    if current_officer.admin?
-      person.response_plans.order(:approved_at).last ||
-        person.response_plans.last
-    else
-      person.active_response_plan
-    end
+    person.active_response_plan
   end
 end

--- a/app/views/application/_menu.html.erb
+++ b/app/views/application/_menu.html.erb
@@ -6,6 +6,11 @@
     </div>
   <% end %>
 
+  <% if current_officer.try(:admin?) %>
+    <%= link_to t("response_plans.draft.index.link"), drafts_path %>
+    <%= link_to t("response_plans.submission.index.link"), submissions_path %>
+  <% end %>
+
   <%= link_to("About", page_path("about")) %>
   <%= link_to("App Updates", page_path("changelog")) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,9 @@ en:
         from_previous: "Created a new draft for %{name}'s response plan."
         from_scratch: "Created a new draft for %{name}'s response plan."
     draft:
+      index:
+        header: Your Drafts
+        link: Your Drafts
       description: This plan will not be visible to patrol officers until it is approved.
       edit: Edit
       submit: Submit for approval
@@ -33,6 +36,9 @@ en:
       new: + Update response plan
       edit: Continue editing your draft
     submission:
+      index:
+        header: Pending Approval
+        link: Pending Approval
       approve: Approve
       description: This plan will not be visible to patrol officers until it is approved.
       title: Pending Approval

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -67,38 +67,21 @@ RSpec.describe PeopleController, type: :controller do
       expect(assigns(:response_plans).keys).to eq([alice, bob, charlie])
     end
 
-    context "as a non-admin" do
-      it "does not show response plans that have not been approved" do
-        officer = create(:officer)
-        approved = create(:response_plan)
-        unapproved = create(:response_plan, approver: nil)
+    it "does not show response plans that have not been approved" do
+      officer = create(:officer)
+      stub_admin_permissions(officer)
+      approved = create(:response_plan)
+      unapproved = create(:response_plan, :submission)
 
-        get :index, {}, { officer_id: officer.id }
+      get :index, {}, { officer_id: officer.id }
 
-        expect(assigns(:response_plans)).to eq(
-          approved.person => approved,
-          # TODO: For now, don't show people without a respones plan.
-          # We'll add them in once we have a plan
-          # for the basic information layout.
-          # unapproved.person => nil,
-        )
-      end
-    end
-
-    context "as an admin" do
-      it "shows response plans that have not been approved" do
-        officer = create(:officer, username: "admin")
-        stub_admin_permissions(officer)
-        approved = create(:response_plan)
-        unapproved = create(:response_plan, approver: nil)
-
-        get :index, {}, { officer_id: officer.id }
-
-        expect(assigns(:response_plans)).to eq(
-          approved.person => approved,
-          unapproved.person => unapproved,
-        )
-      end
+      expect(assigns(:response_plans)).to eq(
+        approved.person => approved,
+        # TODO: For now, don't show people without a response plan.
+        # We'll add them in once we have a plan
+        # for the basic information layout.
+        # unapproved.person => nil,
+      )
     end
   end
 
@@ -115,7 +98,7 @@ RSpec.describe PeopleController, type: :controller do
     end
 
     context "when a plan is being drafted by the current officer" do
-      it "shows the response plan information" do
+      it "does not show the response plan information" do
         officer = create(:officer)
         stub_admin_permissions(officer)
         plan = create(:response_plan, :draft, author: officer)
@@ -123,7 +106,7 @@ RSpec.describe PeopleController, type: :controller do
 
         get :show, { id: person.id }, { officer_id: officer.id }
 
-        expect(assigns(:response_plan)).to eq(plan)
+        expect(assigns(:response_plan)).to eq(nil)
       end
     end
 

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+require "support/permissions"
+
+RSpec.describe "Navigation" do
+  include Permissions
+
+  context "as an admin" do
+    before(:each) do
+      officer = create(:officer)
+      stub_admin_permissions(officer)
+      sign_in_officer(officer)
+    end
+
+    scenario "officers can access drafts from home page", :js do
+      visit root_path
+      open_menu
+      click_on t("response_plans.draft.index.link") # "Your Drafts"
+
+      expect(page).to have_header t("response_plans.draft.index.header")
+    end
+
+    scenario "officers can access submissions from home page", :js do
+      visit root_path
+      open_menu
+      click_on t("response_plans.submission.index.link") # "Pending approval"
+
+      expect(page).to have_header t("response_plans.submission.index.header")
+    end
+  end
+
+  context "as a non-admin" do
+    scenario "officers cannot access drafts from home page", :js do
+      visit root_path
+      open_menu
+
+      expect(page).not_to have_link t("response_plans.draft.index.link")
+    end
+
+    scenario "officers cannot access submissions from home page", :js do
+      visit root_path
+      open_menu
+
+      expect(page).not_to have_link t("response_plans.submission.index.link")
+    end
+  end
+
+  def open_menu
+    find(".menu-icon").trigger("click")
+  end
+
+  def have_header(text)
+    have_css("h1", text: text)
+  end
+end

--- a/spec/features/response_plan_lifecycle_spec.rb
+++ b/spec/features/response_plan_lifecycle_spec.rb
@@ -126,7 +126,8 @@ RSpec.feature "Response Plan Lifecycle" do
         officer = create(:officer)
         stub_admin_permissions(officer)
         sign_in_officer(officer)
-        person = create(:response_plan, :submission).person
+        plan = create(:response_plan, :submission, background_info: "unique")
+        person = plan.person
 
         visit submissions_path
         click_on person.shorthand_description
@@ -135,7 +136,7 @@ RSpec.feature "Response Plan Lifecycle" do
         # TODO confirm this redirect path
         expect(current_path).to eq(person_path(person))
         expect(page).to have_content t("response_plans.submission.approval.success", name: person.name)
-        expect(page).not_to have_content t("response_plans.submission.title")
+        expect(page).to have_content plan.background_info
       end
 
       scenario "they cannot approve response plans that are still being drafted"


### PR DESCRIPTION
## Problem

There is no path through the UI
for admin officers to access response plan drafts and submissions.
It is only accessible by directly typing in the URL.

## Solution

Add links to the drafts and submissions pages
in the side menu.