### PR TITLE
Organize translations by controller and action

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -36,7 +36,7 @@ class DraftsController < ApplicationController
 
     redirect_to(
       edit_draft_path(plan),
-      notice: t("response_plans.create.success.#{source}", name: person.name),
+      notice: t(".success.#{source}", name: person.name),
     )
   end
 
@@ -52,7 +52,7 @@ class DraftsController < ApplicationController
     if @response_plan.save
       redirect_to(
         draft_path(@response_plan),
-        notice: t("response_plans.update.success", name: @response_plan.person.name),
+        notice: t(".success", name: @response_plan.person.name),
       )
     else
       render :edit

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -15,7 +15,7 @@ class SubmissionsController < ApplicationController
   def create
     plan = ResponsePlan.find_by(params[:id])
     plan.update!(submitted_for_approval_at: Time.current)
-    redirect_to :drafts, notice: t("response_plans.draft.submitted")
+    redirect_to :drafts, notice: t(".success")
   end
 
   # Approve a response plan,
@@ -28,12 +28,12 @@ class SubmissionsController < ApplicationController
     if plan.save
       redirect_to(
         person_path(plan.person),
-        notice: t("response_plans.submission.approval.success", name: plan.person.name),
+        notice: t(".success", name: plan.person.name),
       )
     else
       redirect_to(
         person_path(plan.person),
-        alert: t("response_plans.submission.approval.failure"),
+        alert: t(".failure"),
       )
     end
   end

--- a/app/views/application/_menu.html.erb
+++ b/app/views/application/_menu.html.erb
@@ -7,8 +7,8 @@
   <% end %>
 
   <% if current_officer.try(:admin?) %>
-    <%= link_to t("response_plans.draft.index.link"), drafts_path %>
-    <%= link_to t("response_plans.submission.index.link"), submissions_path %>
+    <%= link_to t("drafts.index.link"), drafts_path %>
+    <%= link_to t("submissions.index.link"), submissions_path %>
   <% end %>
 
   <%= link_to("About", page_path("about")) %>

--- a/app/views/drafts/_title.html.erb
+++ b/app/views/drafts/_title.html.erb
@@ -1,18 +1,18 @@
 <section class="page-title section-notice">
   <h1 class="section-title">
-    <%= t("response_plans.draft.title") %>
+    <%= t("drafts.show.title") %>
   </h1>
 
   <div class="description">
-    <%= t("response_plans.draft.description") %>
+    <%= t("drafts.show.description") %>
   </div>
 
   <div class="page-title-actions">
-    <%= link_to t("response_plans.draft.edit"), edit_draft_path(draft) %>
+    <%= link_to t("drafts.show.edit"), edit_draft_path(draft) %>
     or
     <strong>
       <%= link_to(
-        t("response_plans.draft.submit"),
+        t("drafts.show.submit"),
         submissions_path(response_plan_id: draft),
         method: :post,
       ) %>

--- a/app/views/people/_title.html.erb
+++ b/app/views/people/_title.html.erb
@@ -5,7 +5,7 @@
 
       <span class="page-title-action">
         <%= link_to(
-          t("response_plans.draft.new"),
+          t("people.show.new_draft"),
           drafts_path(person_id: person.id),
           method: :post,
         ) %>
@@ -19,7 +19,7 @@
 
     <span class="page-title-action">
       <%= link_to(
-        t("response_plans.new.action"),
+        t("people.show.new_plan"),
         drafts_path(person_id: person.id),
         method: :post,
       ) %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -18,11 +18,7 @@
   </div>
 
   <div class="right-column">
-    <%= render(
-      "sections/title",
-      person: @person,
-      response_plan: @response_plan,
-    ) %>
+    <%= render "title", person: @person, response_plan: @response_plan %>
 
     <% if @response_plan %>
       <%= render "sections/deescalation_techniques", plan: @response_plan %>

--- a/app/views/submissions/_title.html.erb
+++ b/app/views/submissions/_title.html.erb
@@ -1,15 +1,15 @@
 <section class="page-title section-notice">
   <h1 class="section-title">
-    <%= t("response_plans.submission.title") %>
+    <%= t("submissions.show.title") %>
   </h1>
 
   <div class="description">
-    <%= t("response_plans.submission.description") %>
+    <%= t("submissions.show.description") %>
   </div>
 
   <div class="page-title-actions">
     <%= link_to(
-      t("response_plans.submission.approve"),
+      t("submissions.show.approve"),
       approve_submission_path(submission),
       method: :patch,
     ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,16 @@
 en:
+  authentication:
+    sign_in:
+      link: Sign in
+      success: Signed in as %{name}
+      failure: Your username or password was incorrect. Please try again.
+    sign_out:
+      link: Sign out
+      success: Successfully signed out.
+    unauthenticated: Please sign in to continue.
+    unauthorized:
+      new_response_plan: You are not allowed to create new response plans.
+
   date:
     formats:
       default:
@@ -7,8 +19,24 @@ en:
         "%a %m/%d/%y"
 
   demo:
-    notice: This app is in demo mode – the data you see is not real.
     admin: You have admin permissions.
+    notice: This app is in demo mode – the data you see is not real.
+
+  drafts:
+    create:
+      success:
+        from_previous: "Created a new draft for %{name}'s response plan."
+        from_scratch: "Created a new draft for %{name}'s response plan."
+    index:
+      link: Your Drafts
+      title: Your Drafts
+    show:
+      description: This plan will not be visible to patrol officers until it is approved.
+      edit: Continue editing your response plan
+      submit: Submit for approval
+      title: Draft
+    update:
+      success: "Updated %{name}'s response plan"
 
   feedbacks:
     create:
@@ -19,60 +47,10 @@ en:
       search:
         create: Search
 
-  response_plans:
-    create:
-      success:
-        from_previous: "Created a new draft for %{name}'s response plan."
-        from_scratch: "Created a new draft for %{name}'s response plan."
-    draft:
-      index:
-        header: Your Drafts
-        link: Your Drafts
-      description: This plan will not be visible to patrol officers until it is approved.
-      edit: Edit
-      submit: Submit for approval
-      submitted: Submitted for approval
-      title: Draft
-      new: + Update response plan
-      edit: Continue editing your draft
-    submission:
-      index:
-        header: Pending Approval
-        link: Pending Approval
-      approve: Approve
-      description: This plan will not be visible to patrol officers until it is approved.
-      title: Pending Approval
-      approval:
-        success: "Approved %{name}'s response plan. It is now visible to patrol officers"
-        failure: You cannot approve response plans that you wrote.
-    new:
-      action: + Add a response plan
-    update:
-      success: "Updated %{name}'s response plan"
-
-  authentication:
-    unauthenticated: Please sign in to continue.
-    sign_in:
-      link: Sign in
-      success: Signed in as %{name}
-      failure: Your username or password was incorrect. Please try again.
-    sign_out:
-      link: Sign out
-      success: Successfully signed out.
-    unauthorized:
-      new_response_plan: You are not allowed to create new response plans.
-
-  time:
-    formats:
-      default:
-        "%a, %b %-d, %Y at %r"
-      date:
-        "%b %-d, %Y"
-      short:
-        "%B %d"
-
-  titles:
-    application: Crisis Response App
+  people:
+    show:
+      new_plan: + Add a response plan
+      new_draft: + Update response plan
 
   search:
     results:
@@ -89,8 +67,8 @@ en:
   simple_form:
     labels:
       feedback:
-        name: 'Your name'
-        description: 'Feedback'
+        description: Feedback
+        name: Your name
     placeholders:
       feedback:
         name: First Last
@@ -100,3 +78,29 @@ en:
           - What happened
           - What you were doing in the app when the issue occurred
           - What page you were on
+
+  submissions:
+    approve:
+      failure: You cannot approve response plans that you wrote.
+      success: "Approved %{name}'s response plan. It is now visible to patrol officers"
+    create:
+      success: Submitted for approval
+    index:
+      link: Pending Approval
+      title: Pending Approval
+    show:
+      approve: Approve
+      description: This plan will not be visible to patrol officers until it is approved.
+      title: Pending Approval
+
+  time:
+    formats:
+      default:
+        "%a, %b %-d, %Y at %r"
+      date:
+        "%b %-d, %Y"
+      short:
+        "%B %d"
+
+  titles:
+    application: Crisis Response App

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe "Navigation" do
     scenario "officers can access drafts from home page", :js do
       visit root_path
       open_menu
-      click_on t("response_plans.draft.index.link") # "Your Drafts"
+      click_on t("drafts.index.link") # "Your Drafts"
 
-      expect(page).to have_header t("response_plans.draft.index.header")
+      expect(page).to have_header t("drafts.index.title")
     end
 
     scenario "officers can access submissions from home page", :js do
       visit root_path
       open_menu
-      click_on t("response_plans.submission.index.link") # "Pending approval"
+      click_on t("submissions.index.link") # "Pending approval"
 
-      expect(page).to have_header t("response_plans.submission.index.header")
+      expect(page).to have_header t("submissions.index.title")
     end
   end
 
@@ -33,14 +33,14 @@ RSpec.describe "Navigation" do
       visit root_path
       open_menu
 
-      expect(page).not_to have_link t("response_plans.draft.index.link")
+      expect(page).not_to have_link t("drafts.index.link")
     end
 
     scenario "officers cannot access submissions from home page", :js do
       visit root_path
       open_menu
 
-      expect(page).not_to have_link t("response_plans.submission.index.link")
+      expect(page).not_to have_link t("submissions.index.link")
     end
   end
 

--- a/spec/features/officer_views_response_plan_spec.rb
+++ b/spec/features/officer_views_response_plan_spec.rb
@@ -143,34 +143,15 @@ feature "Officer views a response plan" do
     expect(page).to have_content(contact.notes)
   end
 
-  scenario "They see the preparing officer" do
+  scenario "They see the author and approver" do
     sign_in_officer
-    officer = create(:officer, name: "Jacques Clouseau")
-    response_plan = create(:response_plan, author: officer)
+    author = create(:officer, name: "Jacques Clouseau")
+    approver = create(:officer, name: "Sherlock Holmes")
+    response_plan = create(:response_plan, author: author, approver: approver)
 
     visit person_path(response_plan.person)
 
     expect(page).to have_content("Prepared by Jacques Clouseau")
-  end
-
-  context "when the response plan has been approved" do
-    scenario "they don't see a note that it needs approval" do
-      sign_in_officer
-      response_plan = create(:response_plan)
-
-      visit person_path(response_plan.person)
-
-      expect(page).not_to have_content(t("response_plans.submission.title"))
-    end
-
-    scenario "They see the approving officer" do
-      sign_in_officer
-      officer = create(:officer, name: "Jacques Clouseau")
-      response_plan = create(:response_plan, approver: officer)
-
-      visit person_path(response_plan.person)
-
-      expect(page).to have_content("Approved by Jacques Clouseau")
-    end
+    expect(page).to have_content("Approved by Sherlock Holmes")
   end
 end

--- a/spec/features/response_plan_form_spec.rb
+++ b/spec/features/response_plan_form_spec.rb
@@ -11,7 +11,7 @@ feature "Response Plan Form" do
       person = create(:person)
 
       visit person_path(person)
-      click_on t("response_plans.new.action")
+      click_on t("people.show.new_plan")
       fill_in "First name", with: "John"
       fill_in "Last name", with: "Doe"
       fill_in "DOB", with: "1980-01-02"
@@ -19,8 +19,8 @@ feature "Response Plan Form" do
       select "Male", from: "Sex"
       click_on "Update Response plan"
 
-      expect(page).to have_content(t("response_plans.update.success", name: "John Doe"))
-      expect(page).to have_content(t("response_plans.draft.title"))
+      expect(page).to have_content t("drafts.update.success", name: "John Doe")
+      expect(page).to have_content t("drafts.show.title")
       expect(page).to have_content("John")
       expect(page).to have_content("Doe")
       expect(page).to have_content(l(Date.new(1980, 1, 2)))
@@ -33,7 +33,7 @@ feature "Response Plan Form" do
       person = create(:person)
 
       visit person_path(person)
-      click_on t("response_plans.new.action")
+      click_on t("people.show.new_plan")
       fill_in "First name", with: "John"
       fill_in "Last name", with: "Doe"
       fill_in "DOB", with: "1980-01-02"
@@ -52,8 +52,8 @@ feature "Response Plan Form" do
       click_on "Update Response plan"
 
       expect(page).
-        to have_content(t("response_plans.update.success", name: "John Doe"))
-      expect(page).to have_content(t("response_plans.draft.title"))
+        to have_content t("drafts.update.success", name: "John Doe")
+      expect(page).to have_content t("drafts.show.title")
       expect(page).to have_content("John")
       expect(page).to have_content("Doe")
       expect(page).to have_content(l(Date.new(1980, 1, 2)))
@@ -73,7 +73,7 @@ feature "Response Plan Form" do
       person = create(:person)
 
       visit person_path(person)
-      click_on t("response_plans.new.action")
+      click_on t("people.show.new_plan")
       fill_in "First name", with: ""
       click_on "Update Response plan"
 
@@ -85,10 +85,10 @@ feature "Response Plan Form" do
       person = create(:person)
 
       visit person_path(person)
-      click_on t("response_plans.new.action")
+      click_on t("people.show.new_plan")
 
       expect(page).
-        to have_content(t("authentication.unauthorized.new_response_plan"))
+        to have_content t("authentication.unauthorized.new_response_plan")
     end
   end
 

--- a/spec/features/response_plan_lifecycle_spec.rb
+++ b/spec/features/response_plan_lifecycle_spec.rb
@@ -16,10 +16,10 @@ RSpec.feature "Response Plan Lifecycle" do
         person = create(:person)
 
         visit person_path(person)
-        click_on t("response_plans.new.action")
+        click_on t("people.show.new_plan")
 
         expect(page).to have_content \
-          t("response_plans.create.success.from_scratch", name: person.name)
+          t("drafts.create.success.from_scratch", name: person.name)
       end
 
       scenario "they can draft a new plan for a person who already has one" do
@@ -29,23 +29,10 @@ RSpec.feature "Response Plan Lifecycle" do
         person = create(:response_plan, :approved).person
 
         visit person_path(person)
-        click_on t("response_plans.draft.new")
+        click_on t("people.show.new_draft")
 
         expect(page).to have_content \
-          t("response_plans.create.success.from_previous", name: person.name)
-      end
-
-      xscenario "they cannot create multiple drafts for a person at the same time" do
-        officer = create(:officer)
-        stub_admin_permissions(officer)
-        sign_in_officer(officer)
-        plan = create(:response_plan, :draft)
-
-        visit person_path(plan.person)
-        click_on t("response_plans.edit.current_draft")
-
-        # TODO confirm this redirect path
-        expect(current_path).to eq(edit_draft_path(plan))
+          t("drafts.create.success.from_previous", name: person.name)
       end
 
       scenario "updating a draft" do
@@ -56,13 +43,13 @@ RSpec.feature "Response Plan Lifecycle" do
         sign_in_officer(officer)
 
         visit person_path(person)
-        click_on t("response_plans.draft.new")
+        click_on t("people.show.new_draft")
         fill_in "Background info", with: "Lorem Ipsum dolor si amet."
         click_on "Update Response plan"
 
-        expect(page).to have_content t("response_plans.draft.title")
+        expect(page).to have_content t("drafts.show.title")
         # expect(page).
-        #   to have_content(t("response_plans.draft.update.success", name: "Mary Doe"))
+        #   to have_content(t("drafts.update.success", name: "Mary Doe"))
       end
     end
   end
@@ -81,7 +68,7 @@ RSpec.feature "Response Plan Lifecycle" do
 
         visit drafts_path
         click_on plan.person.shorthand_description
-        click_on t("response_plans.draft.edit")
+        click_on t("drafts.show.edit")
 
         expect(current_path).to eq(edit_draft_path(plan))
       end
@@ -97,11 +84,11 @@ RSpec.feature "Response Plan Lifecycle" do
 
         visit drafts_path
         click_on plan.person.shorthand_description
-        click_on t("response_plans.draft.submit")
+        click_on t("drafts.show.submit")
 
         # TODO confirm this redirect path
         expect(current_path).to eq(drafts_path)
-        expect(page).to have_content(t("response_plans.draft.submitted"))
+        expect(page).to have_content t("submissions.create.success")
         expect(page).not_to have_content(plan.person.shorthand_description)
       end
 
@@ -131,11 +118,12 @@ RSpec.feature "Response Plan Lifecycle" do
 
         visit submissions_path
         click_on person.shorthand_description
-        click_on t("response_plans.submission.approve")
+        click_on t("submissions.show.approve")
 
         # TODO confirm this redirect path
         expect(current_path).to eq(person_path(person))
-        expect(page).to have_content t("response_plans.submission.approval.success", name: person.name)
+        expect(page).
+          to have_content t("submissions.approve.success", name: person.name)
         expect(page).to have_content plan.background_info
       end
 
@@ -150,10 +138,10 @@ RSpec.feature "Response Plan Lifecycle" do
 
       visit submissions_path
       click_on plan.person.shorthand_description
-      click_on t("response_plans.submission.approve")
+      click_on t("submissions.show.approve")
 
       expect(plan.reload).not_to be_approved
-      expect(page).to have_content(t("response_plans.submission.approval.failure"))
+      expect(page).to have_content t("submissions.approve.failure")
     end
   end
 end


### PR DESCRIPTION
## Problem

The application's translations are disorganized,
which makes it difficult to remember which translation to use
in controllers and views,
and making it difficult to update the copy for a given page.

## Solution

Organize the translations by controller and view.
This is a natural way to think about the translations,
helps keep the context of the current application state,
and is supported by Rails by default.