### PR TITLE
Fix a bug for submissions#create

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -13,7 +13,7 @@ class SubmissionsController < ApplicationController
   # taking it out of draft form
   # and adding it to the submissions page.
   def create
-    plan = ResponsePlan.find_by(params[:id])
+    plan = ResponsePlan.drafts.find(params[:response_plan_id])
     plan.update!(submitted_for_approval_at: Time.current)
     redirect_to :drafts, notice: t(".success")
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
       success: "Approved %{name}'s response plan. It is now visible to patrol officers"
     create:
       success: Submitted for approval
+      failure: Could not submit the response plan.
     index:
       link: Pending Approval
       title: Pending Approval

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -6,13 +6,11 @@ RSpec.describe SubmissionsController do
 
   describe "GET #index" do
     it "only shows plans that are pending approval" do
-      officer = create(:officer)
-      stub_admin_permissions(officer)
       _draft = create(:response_plan, :draft)
       submission = create(:response_plan, :submission)
       _approved = create(:response_plan, :approved)
 
-      get :index, session: { officer_id: officer.id }
+      get :index, session: stubbed_admin_session
 
       expect(assigns(:submissions)).to eq([submission])
     end
@@ -29,15 +27,44 @@ RSpec.describe SubmissionsController do
 
   describe "POST #create" do
     it "displays an error if the user is not the author"
+
+    it "displays an error if the plan is not a draft" do
+      plan = create(:response_plan, :approved)
+
+      expect do
+      post(
+        :create,
+        params: { response_plan_id: plan.id },
+        session: stubbed_admin_session,
+      )
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "submits the response plan for approval" do
+      plan = create(:response_plan, :draft)
+
+      post(
+        :create,
+        params: { response_plan_id: plan.id },
+        session: stubbed_admin_session,
+      )
+
+      plan.reload
+      expect(plan).not_to be_draft
+      expect(plan).to be_submitted
+    end
   end
 
   describe "PATCH #approve" do
     it "approves the response plan if it is pending approval" do
       officer = create(:officer)
-      stub_admin_permissions(officer)
       plan = create(:response_plan, :submission)
 
-      patch :approve, params: { id: plan }, session: { officer_id: officer.id }
+      patch(
+        :approve,
+        params: { id: plan },
+        session: stubbed_admin_session(officer),
+      )
 
       expect(response).to redirect_to(person_path(plan.person))
       expect(flash[:notice]).
@@ -52,5 +79,10 @@ RSpec.describe SubmissionsController do
     context "as a non-admin" do
       it "rejects the user"
     end
+  end
+
+  def stubbed_admin_session(officer = create(:officer))
+    stub_admin_permissions(officer)
+    { officer_id: officer.id }
   end
 end


### PR DESCRIPTION
## Problem

The action was updating the first response plan in the database,
instead of the one passed to it in the URL params.

## Solution

Add a regression test and fix the bug.