### PR TITLE
Fix bug when removing filters, add spec

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -52,6 +52,10 @@ class Search
     end
   end
 
+  def attributes
+    SEARCHABLE_ATTRS.map { |attr| [attr, public_send(attr)] }.to_h
+  end
+
   def close_matches
     people = @candidates.
       joins("LEFT OUTER JOIN rms_people ON rms_people.person_id = people.id")

--- a/app/views/people/_search_results.html.erb
+++ b/app/views/people/_search_results.html.erb
@@ -19,7 +19,7 @@
             </span>
 
             <%= link_to(
-              people_path(search: params[:search].except(filter)),
+              people_path(search: @search.attributes.except(filter)),
               class: "filter-remove",
             ) do %>
               <%= image_tag "remove-#{theme}.svg" %>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -29,6 +29,10 @@ feature "Search" do
     expect(page).to have_content(t("search.results.none"))
     expect(page).not_to have_content("John")
     expect(page).not_to have_content(l(dob))
+
+    find(".filter-remove").click
+    expect(page).to have_content("John")
+    expect(page).to have_content(l(dob))
   end
 
   scenario "Officer searches for a malformed date" do


### PR DESCRIPTION
## Problem

Rails 5 changed the way the URL helper worked,
which broke the behavior for removing filters from a search.

## Solution

Add a specific test case to catch the regression,
then fix it.