### PR TITLE
List peoples' common behaviors w/ count, percent

### DIFF
--- a/app/models/rms/crisis_incident.rb
+++ b/app/models/rms/crisis_incident.rb
@@ -1,3 +1,54 @@
-class RMS::CrisisIncident < ActiveRecord::Base
-  belongs_to :rms_person, class_name: "RMS::Person"
+# frozen_string_literal: true
+
+module RMS
+  class CrisisIncident < ActiveRecord::Base
+    belongs_to :rms_person, class_name: "RMS::Person"
+
+    BEHAVIORS = [
+      :weapon,
+      :threaten_violence,
+      :biologically_induced,
+      :medically_induced,
+      :chemically_induced,
+      :unknown_crisis_nature,
+      :neglect_self_care,
+      :disorganize_communication,
+      :disoriented_confused,
+      :disorderly_disruptive,
+      :unusual_fright_scared,
+      :belligerent_uncooperative,
+      :hopeless_depressed,
+      :bizarre_unusual_behavior,
+      :suicide_threat_attempt,
+      :mania,
+      :out_of_touch_reality,
+      :halluc_delusion,
+      :excited_delirium,
+      :chronic,
+      :treatment_referral,
+      :resource_declined,
+      :mobile_crisis_team,
+      :grat,
+      :shelter,
+      :no_action_poss_necc,
+      :casemanager_notice,
+      :dmhp_refer,
+      :crisis_clinic,
+      :emergent_ita,
+      :voluntary_commit,
+      :arrested,
+      :verbalization,
+    ].freeze
+
+    def self.frequent_behaviors
+      behaviors_by_incident = pluck(*BEHAVIORS)
+
+      BEHAVIORS.map.with_index do |behavior, index|
+        [
+          behavior,
+          behaviors_by_incident.count { |incident| incident[index] },
+        ]
+      end.reject { |_, count| count.zero? }.to_h
+    end
+  end
 end

--- a/app/views/application/_profile.html.erb
+++ b/app/views/application/_profile.html.erb
@@ -29,6 +29,8 @@ Optional variables:
     <%= render "past_year_incident_count", person: person %>
     <%= render "recent_incident_count", person: person %>
 
+    <%= render "sections/behaviors", person: person %>
+
     <% if plan %>
       <%= render "sections/deescalation_techniques", plan: plan %>
       <%= render "sections/triggers", plan: plan %>

--- a/app/views/sections/_behaviors.html.erb
+++ b/app/views/sections/_behaviors.html.erb
@@ -1,0 +1,26 @@
+<section class="behaviors">
+  <div class="section-header section-header-muted">
+    <div class="section-header-text">
+      <span class="section-title">Behaviors</span>
+    </div>
+  </div>
+
+  <div class="section-body">
+    <ul>
+      <% person.
+        incidents_since(1.year.ago).
+        frequent_behaviors.
+        sort_by { |_, count| count }.
+        reverse.
+        each do |behavior, count| %>
+        <li class="behavior">
+          <span class="behavior-name"><%= behavior.to_s.titleize %></span>
+          <span class="behavior-count"><%= count %></span>
+          <span class="behavior-frequency">
+            (<%= 100 * count / person.incidents_since(1.year.ago).count %>%)
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</section>

--- a/spec/features/core_profile_spec.rb
+++ b/spec/features/core_profile_spec.rb
@@ -24,4 +24,15 @@ feature "Core Profile" do
 
     expect(page).not_to have_content t("profile.core.incident_count.recent")
   end
+
+  it "shows recent behaviors" do
+    sign_in_officer
+    rms_person = create(:rms_person)
+    create(:incident, mania: true, rms_person: rms_person)
+    create(:incident, mania: false, rms_person: rms_person)
+
+    visit person_path(rms_person.person)
+
+    expect(page).to have_content "Mania 1 (50%)"
+  end
 end

--- a/spec/models/rms/crisis_incident_spec.rb
+++ b/spec/models/rms/crisis_incident_spec.rb
@@ -1,4 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe RMS::CrisisIncident, type: :model do
+  describe ".frequent_behaviors" do
+    it "returns a hash of behavior -> count based on incidents" do
+      create(
+        :incident,
+        mania: true,
+        disoriented_confused: true,
+        excited_delirium: false,
+      )
+      create(
+        :incident,
+        mania: false,
+        disoriented_confused: true,
+        excited_delirium: false,
+      )
+
+      expect(RMS::CrisisIncident.frequent_behaviors).to eq(
+        disoriented_confused: 2,
+        mania: 1,
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Feature

**As** a patrol officer,
**When I** am responding to a call about a person in crisis,
**I want to see** their previous behaviors when interacting with police
**So I can** have an idea of what to expect in the upcoming situation.

## Implementation

* Create a class method, `RMS::CrisisIncident.frequent_behaviors`,
  to return a hash of behaviors and their counts
  for any `RMS::CrisisIncident` relation.
  Example: `person.incidents_since(1.week.ago).frequent_behaviors`.
* Display the frequent behaviors on the core profile page.