### PR TITLE
Display crisis narratives in core profiles

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -3,6 +3,8 @@ class Person < ActiveRecord::Base
   include PersonValidations
   include Analytics
 
+  RECENCY_TIMEFRAME = 1.year
+
   attr_accessor :height_feet, :height_inches
 
   before_create :generate_analytics_token
@@ -100,6 +102,10 @@ class Person < ActiveRecord::Base
     Rails.cache.fetch([self, "profile_image_url"]) do
       images.first.try(:source_url) || "/default_profile.png"
     end
+  end
+
+  def recent_incidents
+    incidents_since(RECENCY_TIMEFRAME.ago)
   end
 
   def save(*args)

--- a/app/models/rms/crisis_incident.rb
+++ b/app/models/rms/crisis_incident.rb
@@ -1,3 +1,54 @@
-class RMS::CrisisIncident < ActiveRecord::Base
-  belongs_to :rms_person, class_name: "RMS::Person"
+# frozen_string_literal: true
+
+module RMS
+  class CrisisIncident < ActiveRecord::Base
+    belongs_to :rms_person, class_name: "RMS::Person"
+
+    BEHAVIORS = [
+      :weapon,
+      :threaten_violence,
+      :biologically_induced,
+      :medically_induced,
+      :chemically_induced,
+      :unknown_crisis_nature,
+      :neglect_self_care,
+      :disorganize_communication,
+      :disoriented_confused,
+      :disorderly_disruptive,
+      :unusual_fright_scared,
+      :belligerent_uncooperative,
+      :hopeless_depressed,
+      :bizarre_unusual_behavior,
+      :suicide_threat_attempt,
+      :mania,
+      :out_of_touch_reality,
+      :halluc_delusion,
+      :excited_delirium,
+      :chronic,
+      :treatment_referral,
+      :resource_declined,
+      :mobile_crisis_team,
+      :grat,
+      :shelter,
+      :no_action_poss_necc,
+      :casemanager_notice,
+      :dmhp_refer,
+      :crisis_clinic,
+      :emergent_ita,
+      :voluntary_commit,
+      :arrested,
+      :verbalization,
+    ].freeze
+
+    def self.frequent_behaviors
+      behaviors_by_incident = pluck(*BEHAVIORS)
+
+      BEHAVIORS.map.with_index do |behavior, index|
+        [
+          behavior,
+          behaviors_by_incident.count { |incident| incident[index] },
+        ]
+      end.reject { |_, count| count.zero? }.to_h
+    end
+  end
 end

--- a/app/models/rms/crisis_incident.rb
+++ b/app/models/rms/crisis_incident.rb
@@ -50,5 +50,9 @@ module RMS
         ]
       end.reject { |_, count| count.zero? }.to_h
     end
+
+    def behaviors
+      BEHAVIORS.select { |behavior| public_send(behavior) }
+    end
   end
 end

--- a/app/views/application/_past_year_incident_count.html.erb
+++ b/app/views/application/_past_year_incident_count.html.erb
@@ -1,7 +1,7 @@
 <section class="past-year-incident-count">
   <div class="section-body">
     <span class="incident-count">
-      <%= pluralize(person.incidents_since(1.year.ago).count, "crisis call") %>
+      <%= pluralize(person.recent_incidents.count, "crisis call") %>
     </span>
 
     <span class="secondary">

--- a/app/views/application/_profile.html.erb
+++ b/app/views/application/_profile.html.erb
@@ -29,6 +29,8 @@ Optional variables:
     <%= render "past_year_incident_count", person: person %>
     <%= render "recent_incident_count", person: person %>
 
+    <%= render "sections/behaviors", person: person %>
+
     <% if plan %>
       <%= render "sections/deescalation_techniques", plan: plan %>
       <%= render "sections/triggers", plan: plan %>

--- a/app/views/application/_profile.html.erb
+++ b/app/views/application/_profile.html.erb
@@ -30,6 +30,7 @@ Optional variables:
     <%= render "recent_incident_count", person: person %>
 
     <%= render "sections/behaviors", person: person %>
+    <%= render "sections/incidents", person: person %>
 
     <% if plan %>
       <%= render "sections/deescalation_techniques", plan: plan %>

--- a/app/views/sections/_behaviors.html.erb
+++ b/app/views/sections/_behaviors.html.erb
@@ -1,0 +1,26 @@
+<section class="behaviors">
+  <div class="section-header section-header-muted">
+    <div class="section-header-text">
+      <span class="section-title">Behaviors</span>
+    </div>
+  </div>
+
+  <div class="section-body">
+    <ul>
+      <% person.
+        incidents_since(1.year.ago).
+        frequent_behaviors.
+        sort_by { |_, count| count }.
+        reverse.
+        each do |behavior, count| %>
+        <li class="behavior">
+          <span class="behavior-name"><%= behavior.to_s.titleize %></span>
+          <span class="behavior-count"><%= count %></span>
+          <span class="behavior-frequency">
+            (<%= 100 * count / person.incidents_since(1.year.ago).count %>%)
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</section>

--- a/app/views/sections/_behaviors.html.erb
+++ b/app/views/sections/_behaviors.html.erb
@@ -8,7 +8,7 @@
   <div class="section-body">
     <ul>
       <% person.
-        incidents_since(1.year.ago).
+        recent_incidents.
         frequent_behaviors.
         sort_by { |_, count| count }.
         reverse.
@@ -17,7 +17,7 @@
           <span class="behavior-name"><%= behavior.to_s.titleize %></span>
           <span class="behavior-count"><%= count %></span>
           <span class="behavior-frequency">
-            (<%= 100 * count / person.incidents_since(1.year.ago).count %>%)
+            (<%= 100 * count / person.recent_incidents.count %>%)
           </span>
         </li>
       <% end %>

--- a/app/views/sections/_incidents.html.erb
+++ b/app/views/sections/_incidents.html.erb
@@ -1,0 +1,27 @@
+<section class="incidents">
+  <div class="section-header section-header-muted">
+    <div class="section-header-text">
+      <span class="section-title">Incident History</span>
+    </div>
+  </div>
+
+  <div class="section-body">
+    <% person.recent_incidents.each do |incident| %>
+      <div class="incident">
+        <div class="incident-date"><%= l(incident.reported_at.to_date) %></div>
+
+        <ul class="incident-behaviors">
+          <% incident.behaviors.each do |behavior| %>
+            <li class="incident-behavior"><%= behavior %></li>
+          <% end %>
+        </ul>
+
+        <div class="incident-narrative"><%= incident.narrative %></div>
+
+        <a href="#" class="incident-go-link">
+          <%= incident.go_number[0...4] %>-<%= incident.go_number[4..-1] %>
+        </a>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/spec/features/core_profile_spec.rb
+++ b/spec/features/core_profile_spec.rb
@@ -35,4 +35,15 @@ feature "Core Profile" do
 
     expect(page).to have_content "Mania 1 (50%)"
   end
+
+  it "shows recent incident narratives" do
+    sign_in_officer
+    rms_person = create(:rms_person)
+    narrative = "This is a crisis incident narrative."
+    create(:incident, narrative: narrative, rms_person: rms_person)
+
+    visit person_path(rms_person.person)
+
+    expect(page).to have_content(narrative)
+  end
 end

--- a/spec/features/core_profile_spec.rb
+++ b/spec/features/core_profile_spec.rb
@@ -24,4 +24,15 @@ feature "Core Profile" do
 
     expect(page).not_to have_content t("profile.core.incident_count.recent")
   end
+
+  it "shows recent behaviors" do
+    sign_in_officer
+    rms_person = create(:rms_person)
+    create(:incident, mania: true, rms_person: rms_person)
+    create(:incident, mania: false, rms_person: rms_person)
+
+    visit person_path(rms_person.person)
+
+    expect(page).to have_content "Mania 1 (50%)"
+  end
 end

--- a/spec/models/rms/crisis_incident_spec.rb
+++ b/spec/models/rms/crisis_incident_spec.rb
@@ -1,4 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe RMS::CrisisIncident, type: :model do
+  describe ".frequent_behaviors" do
+    it "returns a hash of behavior -> count based on incidents" do
+      create(
+        :incident,
+        mania: true,
+        disoriented_confused: true,
+        excited_delirium: false,
+      )
+      create(
+        :incident,
+        mania: false,
+        disoriented_confused: true,
+        excited_delirium: false,
+      )
+
+      expect(RMS::CrisisIncident.frequent_behaviors).to eq(
+        disoriented_confused: 2,
+        mania: 1,
+      )
+    end
+  end
 end

--- a/spec/models/rms/crisis_incident_spec.rb
+++ b/spec/models/rms/crisis_incident_spec.rb
@@ -22,4 +22,17 @@ RSpec.describe RMS::CrisisIncident, type: :model do
       )
     end
   end
+
+  describe "#behaviors" do
+    it "returns a list of behaviors that have been displayed" do
+      incident = create(
+        :incident,
+        mania: true,
+        disoriented_confused: true,
+        excited_delirium: false,
+      )
+
+      expect(incident.behaviors).to match_array([:mania, :disoriented_confused])
+    end
+  end
 end


### PR DESCRIPTION
## Feature

**As** a patrol officer,
**When I** am deciding how to handle a person in a crisis incident
**I want to** see what happened in previous calls for the individual
**So I can** learn from fellow officers' past experiences.

## Implementation

Query the database for crisis calls within the past year, and display those
calls in the profile, along with the narrative, displayed behaviors, and
date.