### PR TITLE
Fix import for malformed height strings

### DIFF
--- a/lib/rms_person_parser.rb
+++ b/lib/rms_person_parser.rb
@@ -47,7 +47,8 @@ class RMSPersonParser
     height = data.fetch("HEIGHT")
 
     if height
-      feet, inches = height.split("'")
+      feet = height.strip[0]
+      inches = height.strip[1..-1].scan(/\d+/).first
       feet.to_i * 12 + inches.to_i
     end
   end

--- a/spec/lib/rms_person_parser_spec.rb
+++ b/spec/lib/rms_person_parser_spec.rb
@@ -81,6 +81,12 @@ describe RMSPersonParser do
       expect(parser.height_in_inches).to eq(66)
     end
 
+    it "handles height without delimeters" do
+      parser = RMSPersonParser.new("HEIGHT" => "506")
+
+      expect(parser.height_in_inches).to eq(66)
+    end
+
     it "handles nil" do
       parser = RMSPersonParser.new("HEIGHT" => nil)
 


### PR DESCRIPTION
## Problem

Some people have their height stored
without delimiters between feet and inches,
such as `505` instead of `5'05"`.
For these people, our import script assigns wildly unrealistic heights,
such as `505'0"`.
## Solution

Adjust the import script to handle heights without delimiters.
