### PR TITLE
Don't display people below a certain threshold of crisis incidents

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -4,7 +4,7 @@ class PeopleController < ApplicationController
   before_action :authenticate_officer!
 
   def index
-    @search = Search.new(search_params)
+    @search = Search.new(search_params, Person.visible)
     @search.validate
 
     @people = @search.

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -76,6 +76,10 @@ class Person < ActiveRecord::Base
   fallback_to_rms_person(:weight_in_pounds)
   fallback_to_rms_person(:weight_in_pounds)
 
+  def self.visible
+    where(visible: true)
+  end
+
   def active_plan
     @active_plan ||= response_plans.
       approved.

--- a/db/migrate/20160913212716_add_visible_to_people.rb
+++ b/db/migrate/20160913212716_add_visible_to_people.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVisibleToPeople < ActiveRecord::Migration[5.0]
+  def change
+    add_column :people, :visible, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160908191644) do
+ActiveRecord::Schema.define(version: 20160913212716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,8 +98,8 @@ ActiveRecord::Schema.define(version: 20160908191644) do
   end
 
   create_table "people", force: :cascade do |t|
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.string   "first_name"
     t.string   "last_name"
     t.string   "sex"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20160908191644) do
     t.string   "analytics_token"
     t.string   "location_name"
     t.string   "location_address"
+    t.boolean  "visible",          default: false, null: false
   end
 
   create_table "response_plans", force: :cascade do |t|

--- a/lib/rms_importer.rb
+++ b/lib/rms_importer.rb
@@ -22,10 +22,9 @@ class RMSImporter
     create_log_path
 
     results = query(SQL_QUERY)
+    results.each { |result| parse_sql_result(result) }
 
-    results.each do |result|
-      parse_sql_result(result)
-    end
+    Person.update_visibility
 
     log_unimported_incidents
     log_duplicate_incidents(results)

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe PeopleController, type: :controller do
       expect(assigns(:people)).to eq([person])
     end
 
+    it "does not show people below the threshold" do
+      officer = create(:officer, username: "foobar")
+      create(:person, visible: false)
+
+      get :index, session: { officer_id: officer.id }
+
+      expect(assigns(:people)).to be_empty
+    end
+
     it "shows people in alphabetical order" do
       officer = create(:officer)
       charlie = create(:person, last_name: "Charlie")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -54,6 +54,7 @@ FactoryGirl.define do
     hair_color "black"
     eye_color "blue"
     date_of_birth { 25.years.ago }
+    visible true
   end
 
   factory :response_plan do

--- a/spec/lib/rms_importer_spec.rb
+++ b/spec/lib/rms_importer_spec.rb
@@ -204,9 +204,16 @@ describe RMSImporter do
     end
   end
 
-  describe "database resource constraints" do
-    xit "fetches incidents in batches of less than 100k"
-    xit "fetches people in batches of less than 100k"
+  describe "threshold" do
+    it "updates the person's visibility" do
+      stub_crisis_incidents
+      person = create(:person, visible: true)
+
+      RMSImporter.new.import
+
+      person.reload
+      expect(person).not_to be_visible
+    end
   end
 
   private

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe Person, type: :model do
     it_should_behave_like "a validated person"
   end
 
+  describe ".visible" do
+    it "returns people who are visible" do
+      visible = create(:person, visible: true)
+      create(:person, visible: false)
+
+      expect(Person.visible).to eq([visible])
+    end
+  end
+
   describe "#active_plan" do
     it "returns the most recent approved response plan" do
       person = create(:person)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -15,6 +15,44 @@ RSpec.describe Person, type: :model do
     it_should_behave_like "a validated person"
   end
 
+  describe ".update_visibility" do
+    it "sets `visible` if # of recent incidents are below the threshold" do
+      rms_person = create(:rms_person)
+      person = rms_person.person
+      person.update(visible: false)
+      create_list(
+        :incident,
+        Person::RECENT_INCIDENT_THRESHOLD,
+        rms_person: rms_person,
+      )
+
+      Person.update_visibility
+
+      person.reload
+      expect(person).to be_visible
+    end
+
+    it "sets `visible` if there is an active response plan" do
+      person = create(:person, visible: false)
+      create(:response_plan, :approved, person: person)
+
+      Person.update_visibility
+
+      person.reload
+      expect(person).to be_visible
+    end
+
+    it "unsets `visible` if # of recent incidents are below the threshold" do
+      person = create(:rms_person).person
+      person.update(visible: true)
+
+      Person.update_visibility
+
+      person.reload
+      expect(person).not_to be_visible
+    end
+  end
+
   describe ".visible" do
     it "returns people who are visible" do
       visible = create(:person, visible: true)


### PR DESCRIPTION
For implementation details, see the individual commit messages.

At the moment, the threshold is set to 12.
After changing the number, run `Person.update_visibility` in the Rails console.