### PR TITLE
Index people based on visibility

### DIFF
--- a/db/migrate/20160913212716_add_visible_to_people.rb
+++ b/db/migrate/20160913212716_add_visible_to_people.rb
@@ -3,5 +3,6 @@
 class AddVisibleToPeople < ActiveRecord::Migration[5.0]
   def change
     add_column :people, :visible, :boolean, null: false, default: false
+    add_index :people, :visible
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -114,6 +114,7 @@ ActiveRecord::Schema.define(version: 20160913212716) do
     t.string   "location_name"
     t.string   "location_address"
     t.boolean  "visible",          default: false, null: false
+    t.index ["visible"], name: "index_people_on_visible", using: :btree
   end
 
   create_table "response_plans", force: :cascade do |t|


### PR DESCRIPTION
We are often querying and displaying only visible people.
To speed up this query, we should index on the person's visibility.