### PR TITLE
Don't rely on Google Maps to populate UI address

### DIFF
--- a/app/assets/javascripts/application/location.js
+++ b/app/assets/javascripts/application/location.js
@@ -39,7 +39,6 @@ function initMap() {
   }, function(result) {
     var result = result[0];
 
-    fillInAddress(result.formatted_address);
     var map = setUpMap(result.geometry.location);
 
     $(".zoom-out").on("click", function() { map.setZoom(map.zoom - 1); });
@@ -66,16 +65,5 @@ function initMap() {
     }, 1000);
 
     return map;
-  }
-
-  function fillInAddress(address) {
-    address_parts = address.split(", ");
-    address_parts.pop(); // Remove country
-
-    var line_one = address_parts.shift();
-    var line_two = address_parts.join(", ");
-
-    $(".location-address-line-one").text(line_one);
-    $(".location-address-line-two").text(line_two);
   }
 }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -106,6 +106,14 @@ class Person < ActiveRecord::Base
       last
   end
 
+  def address_line_one
+    location_address.split(",").first
+  end
+
+  def address_line_two
+    location_address.split(",")[1..-1].join(",")
+  end
+
   def display_name
     "#{last_name}, #{first_name}"
   end

--- a/app/views/sections/_location.html.erb
+++ b/app/views/sections/_location.html.erb
@@ -15,8 +15,13 @@
       </span>
 
       <span class="location-address">
-        <span class="location-address-line-one"></span>
-        <span class="location-address-line-two"></span>
+        <span class="location-address-line-one">
+          <%= person.address_line_one %>
+        </span>
+
+        <span class="location-address-line-two">
+          <%= person.address_line_two %>
+        </span>
       </span>
     </div>
 

--- a/spec/features/person_profile_spec.rb
+++ b/spec/features/person_profile_spec.rb
@@ -62,6 +62,21 @@ feature "Officer views a response plan" do
     expect(page).to have_content("Skull tattoo on neck")
   end
 
+  scenario "They see the person's location" do
+    sign_in_officer
+    person = create(
+      :person,
+      location_name: "Residence",
+      location_address: "123 Main St, Seattle, WA",
+    )
+
+    visit person_path(person)
+
+    expect(page).to have_content("Residence")
+    expect(page).to have_content("123 Main St")
+    expect(page).to have_content("Seattle, WA")
+  end
+
   scenario "They see the person's aliases" do
     sign_in_officer
     aliases = ["Mark Smith", "Joe Andrews"]


### PR DESCRIPTION
When Google Maps didn't recognize an address
it would populate the UI with something generic
like "King County, WA".

This is less than useless to patrol officers,
so we'll stop using Google Maps as an intermediary
when we display the addresses.

The map and address may be out of sync,
but most officers seem not to use the map anyway.