### PR TITLE
Let admins see all plans, above or below threshold

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -4,7 +4,7 @@ class PeopleController < ApplicationController
   before_action :authenticate_officer!
 
   def index
-    @search = Search.new(search_params, Person.visible)
+    @search = Search.new(search_params, visible_people)
     @search.validate
 
     @people = @search.
@@ -16,7 +16,7 @@ class PeopleController < ApplicationController
   end
 
   def show
-    @person = Person.includes(:images).find(params[:id])
+    @person = visible_people.includes(:images).find(params[:id])
 
     PageView.create(officer: current_officer, person: @person)
   end
@@ -39,6 +39,14 @@ class PeopleController < ApplicationController
       )
     else
       {}
+    end
+  end
+
+  def visible_people
+    if current_officer.admin?
+      Person.all
+    else
+      Person.publicly_visible
     end
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -98,7 +98,7 @@ class Person < ApplicationRecord
     Person.where(id: people_ids).update_all(visible: true)
   end
 
-  def self.visible
+  def self.publicly_visible
     where(visible: true)
   end
 

--- a/spec/features/core_profile_spec.rb
+++ b/spec/features/core_profile_spec.rb
@@ -49,4 +49,24 @@ feature "Core Profile" do
     expect(page).to have_content(narrative)
     expect(current_path).to eq(incident_path(incident))
   end
+
+  scenario "admins can view non-visible profiles" do
+    admin = create(:officer, :admin)
+    sign_in_officer(admin)
+    person = create(:person, visible: false)
+
+    visit person_path(person)
+
+    expect(page).to have_content(l(person.date_of_birth))
+  end
+
+  scenario "non-admins can only view visible profiles" do
+    officer = create(:officer)
+    sign_in_officer(officer)
+    person = create(:person, visible: false)
+
+    expect do
+      visit person_path(person)
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -169,6 +169,26 @@ feature "Search" do
       end
     end
 
+    scenario "admins can see non-visible profiles" do
+      admin = create(:officer, :admin)
+      sign_in_officer(admin)
+      person = create(:person, visible: false)
+
+      visit people_path
+
+      expect(page).to have_content(l(person.date_of_birth))
+    end
+
+    scenario "non-admins can only see visible profiles" do
+      officer = create(:officer)
+      sign_in_officer(officer)
+      person = create(:person, visible: false)
+
+      visit people_path
+
+      expect(page).not_to have_content(l(person.date_of_birth))
+    end
+
     def check_option(attr, option)
       page.execute_script("$('.search_#{attr} [value=\"#{option}\"]').click()")
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe Person, type: :model do
     end
   end
 
-  describe ".visible" do
+  describe ".publicly_visible" do
     it "returns people who are visible" do
       visible = create(:person, visible: true)
       create(:person, visible: false)
 
-      expect(Person.visible).to eq([visible])
+      expect(Person.publicly_visible).to eq([visible])
     end
   end
 


### PR DESCRIPTION
## Problem

CRT sometimes needs to create plans for people
who are below the threshold for inclusion in our application.
If they cannot see these people in the app,
they cannot create plans for them.
## Solution

Relax the threshold restriction so it does not apply to CRT officers.
