### PR TITLE
Make bin/serve script more robust

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-# Exit if any subcommand fails
-set -e
-
-bundle check || bundle install
-bundle exec rake assets:precompile
 rm tmp/pids/server.pid
+
+(bundle check || bundle install) &&\
+bundle exec rake assets:precompile &&\
 bundle exec rails s -p 3000 -b 0.0.0.0


### PR DESCRIPTION
The script was set to exit if any subcommand failed,
which meant that if there was no `tmp/pids/server.pid`
then the server would not be able to start.

A bit ironic, actually.
That line was there because the server wouldn't start
if that file *was* present.