### PR TITLE
Run docker-compose in Docker to remove dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We use [Docker] to make it easy
 to develop, package, and deploy the application
 on any platform.
 
-Before starting, install Docker ([mac], [windows], [linux]) and [Docker Compose].
+Before starting, install Docker ([mac], [windows], [linux]).
 
 #### Mac or Windows VM setup
 
@@ -85,20 +85,12 @@ $ docker run --rm hello-world
 Hello from Docker!
 This message shows that your installation appears to be working correctly.
 ...
-
-$ docker-compose version
-# should print something like:
-docker-compose version 1.8.0, build f3628c7
-docker-py version: 1.9.0
-CPython version: 2.7.9
-OpenSSL version: OpenSSL 1.0.2h  3 May 2016
 ```
 
 [Docker]: https://www.docker.com/
 [mac]: https://docs.docker.com/mac/
 [windows]: https://docs.docker.com/windows/
 [linux]: https://docs.docker.com/linux/
-[Docker Compose]: https://docs.docker.com/compose/install/
 [install docker-machine]: https://docs.docker.com/machine/install-machine
 [VirtualBox]: https://www.virtualbox.org/wiki/Downloads
 
@@ -114,7 +106,7 @@ $ git clone git@github.com:codeforamerica/crisisresponse.git && cd crisisrespons
 $ ./bin/setup
 
 # Run the server
-$ docker-compose up
+$ ./bin/docker-compose up
 ```
 
 After those commands,
@@ -127,10 +119,10 @@ that you'll need after you change the application's dependencies:
 ```bash
 # After updating the `Dockerfile` or `Gemfile`,
 # you'll need to rebuild the application container.
-$ docker-compose build
+$ ./bin/docker-compose build
 
 # Push a new docker image to Docker Hub:
-$ docker-compose build && docker push codeforamerica/crisisresponse
+$ ./bin/docker-compose build && docker push codeforamerica/crisisresponse
 ```
 
 ### Running Tests
@@ -147,7 +139,7 @@ or run an individual test file with `./bin/test spec/my/test/file.rb`.
 * run:
 
   ```bash
-  $ app run --rm web rails c
+  $ ./bin/docker-compose run --rm web rails c
   ```
 
 * Inside the rails console, type:
@@ -172,10 +164,10 @@ under the `backups/` subfolder.
 
 ```bash
 # Create a backup of the database
-$ docker-compose run --rm backup
+$ ./bin/docker-compose run --rm backup
 
 # Restore a backup
-$ docker-compose run --rm restore backups/2016-01-02_12:00:00.sql
+$ ./bin/docker-compose run --rm restore backups/2016-01-02_12:00:00.sql
 ```
 
 ## Development Guidelines

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Run docker-compose in a container
+#
+# This script will attempt to mirror the host paths by using volumes for the
+# following paths:
+#   * $(pwd)
+#   * $(dirname $COMPOSE_FILE) if it's set
+#   * $HOME if it's set
+#
+# You can add additional volumes (or any docker run options) using
+# the $COMPOSE_OPTIONS environment variable.
+#
+
+
+set -e
+
+VERSION="1.8.0"
+IMAGE="docker/compose:$VERSION"
+
+
+# Setup options for connecting to docker host
+if [ -z "$DOCKER_HOST" ]; then
+    DOCKER_HOST="/var/run/docker.sock"
+fi
+if [ -S "$DOCKER_HOST" ]; then
+    DOCKER_ADDR="-v $DOCKER_HOST:$DOCKER_HOST -e DOCKER_HOST"
+else
+    DOCKER_ADDR="-e DOCKER_HOST -e DOCKER_TLS_VERIFY -e DOCKER_CERT_PATH"
+fi
+
+
+# Setup volume mounts for compose config and context
+if [ "$(pwd)" != '/' ]; then
+    VOLUMES="-v $(pwd):$(pwd)"
+fi
+if [ -n "$COMPOSE_FILE" ]; then
+    compose_dir=$(dirname $COMPOSE_FILE)
+fi
+# TODO: also check --file argument
+if [ -n "$compose_dir" ]; then
+    VOLUMES="$VOLUMES -v $compose_dir:$compose_dir"
+fi
+if [ -n "$HOME" ]; then
+    VOLUMES="$VOLUMES -v $HOME:$HOME -v $HOME:/root" # mount $HOME in /root to share docker.config
+fi
+
+# Only allocate tty if we detect one
+if [ -t 1 ]; then
+    DOCKER_RUN_OPTIONS="-t"
+fi
+if [ -t 0 ]; then
+    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -i"
+fi
+
+exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE "$@"

--- a/bin/setup
+++ b/bin/setup
@@ -14,6 +14,8 @@ touch .env.local
 
 # Only if this isn't CI
 if [ -z "$CI" ]; then
+  docker pull docker/compose:1.8.0
+
   # Build the docker image
   docker-compose build
 


### PR DESCRIPTION
From https://docs.docker.com/compose/install/#/install-as-a-container:

> Compose can also be run inside a container,
> from a small bash script wrapper.
> To install compose as a container run:

```
$ curl -L https://github.com/docker/compose/releases/download/1.8.0/run.sh > /usr/local/bin/docker-compose
$ chmod +x /usr/local/bin/docker-compose
```

By packaging up `docker-compose` as a binstub script,
we remove `docker-compose` as an explicit dependency
for users setting up our app.
It is one fewer step that they need to complete
to get the app up and running.