### PR TITLE
Only allow one draft for a person at a time

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -34,7 +34,7 @@ class DraftsController < ApplicationController
   before_action :authorize_admin
 
   def index
-    @drafts = ResponsePlan.drafts.where(author: current_officer)
+    @drafts = ResponsePlan.drafts
   end
 
   def show

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -19,6 +19,7 @@ class Person < ApplicationRecord
   has_many :images, dependent: :destroy
   has_many :response_plans
   has_one :rms_person, class_name: "RMS::Person"
+  has_one :draft, -> { drafts }, class_name: "ResponsePlan"
 
   pg_search_scope(
     :search,

--- a/app/models/response_plan.rb
+++ b/app/models/response_plan.rb
@@ -51,7 +51,7 @@ class ResponsePlan < ApplicationRecord
   end
 
   def self.drafts
-    where(submitted_for_approval_at: nil)
+    where(submitted_for_approval_at: nil).where(approved_at: nil)
   end
 
   def self.submitted

--- a/app/views/people/_actions.html.erb
+++ b/app/views/people/_actions.html.erb
@@ -1,7 +1,10 @@
 <div class="page-title-actions">
-  <% if plan %>
+  <% if person.draft %>
+    <%= t("people.show.draft.exists", name: person.first_name) %>
+    <%= link_to t("people.show.draft.show"), draft_path(person.draft) %>
+  <% elsif plan %>
     <%= link_to(
-      t("people.show.new_draft"),
+      t("people.show.draft.new"),
       drafts_path(person_id: person.id),
       method: :post,
     ) %>

--- a/app/views/people/_person.html.erb
+++ b/app/views/people/_person.html.erb
@@ -1,60 +1,58 @@
 <div class="section-body person" role="link" data-link="<%= link %>">
-  <%= cache person do %>
-    <%= image_tag person.profile_image_url %>
+  <%= image_tag person.profile_image_url %>
 
-    <div class="person-information">
-      <span class="person-name">
-        <%= person.last_name.to_s.upcase %>,
-        <%= person.first_name.to_s.titleize %>
-        <%= person.middle_initial.to_s.titleize %>
-      </span>
+  <div class="person-information">
+    <span class="person-name">
+      <%= person.last_name.to_s.upcase %>,
+      <%= person.first_name.to_s.titleize %>
+      <%= person.middle_initial.to_s.titleize %>
+    </span>
 
-      <div class="person-information-profile">
-        <% if person.date_of_birth %>
-          <span class="person-dob">
-            <%= l person.date_of_birth %>
-          </span>
-        <% end %>
-
-        <div class="person-description">
-          <%= person.shorthand_description %>
-        </div>
-      </div>
-
-      <% if person.recent_incidents.frequent_behaviors.any? %>
-        <div class="person-top-behavior">
-          <span class="person-top-behavior-text">
-            <%= t([
-              :incidents,
-              :behaviors,
-              person.recent_incidents.frequent_behaviors.keys.first,
-            ].join(".")) %>
-          </span>
-        </div>
+    <div class="person-information-profile">
+      <% if person.date_of_birth %>
+        <span class="person-dob">
+          <%= l person.date_of_birth %>
+        </span>
       <% end %>
 
-      <div class="person-incident-count">
-        <span class="bold">
-          <%= person.recent_incidents.count %>
-        </span>
-        CRISIS Calls
-      </div>
-
-      <div class="person-links">
-        <% if person.recent_incidents.any? %>
-          <%= link_to(
-            "Last Report",
-            incident_path(person.recent_incidents.first),
-            target: "_blank",
-          ) %>
-        <% end %>
-
-        <% if person.active_plan %>
-          <%= link_to "Response Plan", link, class: "person-link-plan button" %>
-        <% else %>
-          <%= link_to "Profile", link, class: "person-link-profile button" %>
-        <% end %>
+      <div class="person-description">
+        <%= person.shorthand_description %>
       </div>
     </div>
-  <% end %>
+
+    <% if person.recent_incidents.frequent_behaviors.any? %>
+      <div class="person-top-behavior">
+        <span class="person-top-behavior-text">
+          <%= t([
+            :incidents,
+            :behaviors,
+            person.recent_incidents.frequent_behaviors.keys.first,
+          ].join(".")) %>
+        </span>
+      </div>
+    <% end %>
+
+    <div class="person-incident-count">
+      <span class="bold">
+        <%= person.recent_incidents.count %>
+      </span>
+      CRISIS Calls
+    </div>
+
+    <div class="person-links">
+      <% if person.recent_incidents.any? %>
+        <%= link_to(
+          "Last Report",
+          incident_path(person.recent_incidents.first),
+          target: "_blank",
+        ) %>
+      <% end %>
+
+      <% if person.active_plan %>
+        <%= link_to "Response Plan", link, class: "person-link-plan button" %>
+      <% else %>
+        <%= link_to "Profile", link, class: "person-link-profile button" %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,7 +95,10 @@ en:
       failure: Errors prevented the person from being saved.
     show:
       new_plan: + Add a response plan
-      new_draft: + Update response plan
+      draft:
+        new: + Update response plan
+        exists: A new response plan draft is in progress for %{name}.
+        show: View existing draft.
 
   profile:
     actions:

--- a/spec/controllers/drafts_controller_spec.rb
+++ b/spec/controllers/drafts_controller_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe DraftsController do
     it "only shows plans that are drafts" do
       officer = create(:officer, :admin)
       draft = create(:response_plan, :draft, author: officer)
-      _draft_from_other_officer = create(:response_plan, :draft)
+      draft_from_other_officer = create(:response_plan, :draft)
       _pending = create(:response_plan, :submission)
       _approved = create(:response_plan, :approved)
 
       get :index, session: { officer_id: officer.id }
 
-      expect(assigns(:drafts)).to eq([draft])
+      expect(assigns(:drafts)).to eq([draft, draft_from_other_officer])
     end
   end
 
@@ -226,7 +226,6 @@ RSpec.describe DraftsController do
     it "redirects if the officer is not an admin"
     it "redirects if the plan has been approved"
     it "redirects if the plan has been submitted for approval"
-    it "redirects if the current officer did not create the draft"
 
     it "assigns the plan if it is still in draft form" do
       officer = create(:officer, :admin)
@@ -245,11 +244,6 @@ RSpec.describe DraftsController do
   describe "PATCH #update" do
     it "redirects if the officer is not signed in"
     it "redirects if the officer is not an admin"
-
-    context "if the current officer did not create the draft" do
-      it "does not update the plan"
-      it "redirects to the person's page"
-    end
 
     context "if the plan has been submitted for approval" do
       it "does not update the plan"

--- a/spec/models/response_plan_spec.rb
+++ b/spec/models/response_plan_spec.rb
@@ -42,10 +42,11 @@ RSpec.describe ResponsePlan, type: :model do
   end
 
   describe ".drafts" do
-    it "returns response plans that have not been submitted for approval" do
+    it "returns response plans that have not been submitted or approved" do
       draft = create(:response_plan, :draft)
       create(:response_plan, :submission)
       create(:response_plan, :approved)
+      create(:response_plan, :approved, submitted_for_approval_at: nil)
 
       expect(ResponsePlan.drafts).to eq([draft])
     end


### PR DESCRIPTION
## Problem

Admin officers often create multiple drafts for individuals, because the
interface does not do a good job of pointing out when a draft already
exists.

This leads to a lot of confusion about which duplicate draft should be
used.

## Solution

* Don't allow officers to create a new draft if one already exists.
* When a draft exists, give officers a clear link to access that draft
 from the person's profile page.
* Don't list response plans that have already been approved as drafts.

Also, don't cache people's cards on index pages

The cache gets out of sync way too often, which means we present inaccurate
information to our users.