### PR TITLE
Add bar charts for previous incidents

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -13,6 +13,7 @@
 
 @import "authentication";
 @import "behaviors";
+@import "charts";
 @import "deescalation_techniques";
 @import "feedbacks";
 @import "filters";

--- a/app/assets/stylesheets/_charts.scss
+++ b/app/assets/stylesheets/_charts.scss
@@ -1,0 +1,36 @@
+.chart {
+  margin-bottom: $base-spacing;
+}
+
+.chart-field {
+  @include fill-parent;
+  margin-bottom: $small-spacing;
+  overflow: hidden;
+}
+
+.chart-label {
+  @include span-columns(4 of 12);
+  font-size: 0.8em;
+  text-align: right;
+}
+
+.chart-bar-background {
+  @include span-columns(4 of 12);
+  background-color: lighten($action-color, 40%);
+}
+
+.chart-bar {
+  background-color: $action-color;
+  padding-left: 1px;
+}
+
+.chart-field-count {
+  @include heavy-font;
+  margin-right: 0;
+}
+
+.chart-field-frequency {
+  @include light-font;
+  color: $secondary-text-color;
+  font-size: 0.8em;
+}

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -16,7 +16,7 @@ body {
   padding-top: 0;
 }
 
-* {
+*:not(.chart-bar) {
   background: none !important;
 }
 
@@ -98,4 +98,22 @@ section .section-header {
 
 .profile-safety-concerns {
   @include omega;
+}
+
+.ct-chart {
+  transform: scale(0.5) translate(-70px, -30px);
+  left: 0;
+  height: 8em;
+}
+
+.ct-grid {
+  display: none;
+}
+
+.ct-label.ct-horizontal {
+  display: none;
+}
+
+.stat__label {
+  padding-left: 0 !important;
 }

--- a/app/models/rms/crisis_incident.rb
+++ b/app/models/rms/crisis_incident.rb
@@ -49,14 +49,23 @@ module RMS
     ].freeze
 
     def self.frequent_behaviors
-      behaviors_by_incident = pluck(*BEHAVIORS)
+      by_frequency(:behaviors)
+    end
 
-      BEHAVIORS.map.with_index do |behavior, index|
+    def self.by_frequency(category)
+      observations = RMS::CrisisIncident.const_get(category.to_s.upcase)
+      observations_by_incident = pluck(*observations)
+
+      observations.map.with_index do |observation, index|
         [
-          behavior,
-          behaviors_by_incident.count { |incident| incident[index] },
+          observation,
+          observations_by_incident.count { |incident| incident[index] },
         ]
-      end.reject { |_, count| count.zero? }.to_h
+      end.
+        reject { |_, count| count.zero? }.
+        sort_by { |_, count| count }.
+        reverse.
+        to_h
     end
 
     def behaviors

--- a/app/views/people/_chart.html.erb
+++ b/app/views/people/_chart.html.erb
@@ -1,0 +1,25 @@
+<div class="chart <%= category %>">
+  <% incidents.by_frequency(category).each do |field, frequency| %>
+    <div class="chart-field">
+      <span class="chart-label">
+        <%= t("incidents.#{category}.#{field}") %>
+      </span>
+
+      <div class="chart-bar-background">
+        <div
+           class="chart-bar"
+           style="width: <%= frequency / incidents.count.to_f * 100 %>%">
+           &nbsp;
+        </div>
+      </div>
+
+      <div class="chart-field-count">
+        <%= frequency %>
+
+        <span class="chart-field-frequency">
+          (<%= 100 * frequency / incidents.count %>%)
+        </span>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/sections/_behaviors.html.erb
+++ b/app/views/sections/_behaviors.html.erb
@@ -18,8 +18,6 @@
         <% person.
           recent_incidents.
           frequent_behaviors.
-          sort_by { |_, count| count }.
-          reverse.
           first(4).
           each do |behavior, count| %>
           <li class="behavior">

--- a/app/views/sections/_incidents.html.erb
+++ b/app/views/sections/_incidents.html.erb
@@ -30,5 +30,22 @@
         View older crisis calls
       </a>
     </div>
+
+    <div class="section-body">
+      <h3>Behaviors</h3>
+      <%= render "chart",
+        incidents: person.recent_incidents,
+        category: :behaviors %>
+
+      <h3>Nature of Crisis</h3>
+      <%= render "chart",
+        incidents: person.recent_incidents,
+        category: :nature_of_crisis %>
+
+      <h3>Disposition</h3>
+      <%= render "chart",
+        incidents: person.recent_incidents,
+        category: :dispositions %>
+    </div>
   </section>
 <% end %>


### PR DESCRIPTION
We had previously implemented charts with Chartist.js,
but Chartist didn't allow us to customize the labels like we need to,
with the count and percentages to the right of the bars.

Instead, we use divs with different widths to draw bars manually.