### PR TITLE
Tighten down nominal definition of "Response Plan"

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -132,6 +132,10 @@ class Person < ApplicationRecord
     end
   end
 
+  def has_nominal_response_plan?
+    active_plan.try(:response_strategies).try(:any?)
+  end
+
   def height_feet
     height_in_inches.to_i / 12
   end

--- a/app/views/people/_person.html.erb
+++ b/app/views/people/_person.html.erb
@@ -48,7 +48,7 @@
         ) %>
       <% end %>
 
-      <% if person.active_plan %>
+      <% if person.has_nominal_response_plan? %>
         <%= link_to "Response Plan", link, class: "person-link-plan button" %>
       <% else %>
         <%= link_to "Profile", link, class: "person-link-profile button" %>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -169,6 +169,17 @@ feature "Search" do
       end
     end
 
+    scenario "person without response strategies is labeled as having a 'profile'" do
+      plan = create(:safety_concern).response_plan
+
+      sign_in_officer
+      visit people_path
+
+      within(".person") do
+        expect(page).to have_content("PROFILE")
+      end
+    end
+
     scenario "admins can see non-visible profiles" do
       admin = create(:officer, :admin)
       sign_in_officer(admin)


### PR DESCRIPTION
In the UI, we should only display references to a "Response Plan"
if the person has explicit response strategies.

If a person only has deescalation techniques or safety concerns,
for example,
then we should refer to them as only having a core profile.