### PR TITLE
Track visibility through association records

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -87,7 +87,8 @@ class PeopleController < ApplicationController
     if current_officer.admin?
       Person.all
     else
-      Person.publicly_visible
+      people_ids = Visibility.where(removed_at: nil).pluck(:person_id)
+      Person.where(id: people_ids)
     end
   end
 end

--- a/app/models/visibility.rb
+++ b/app/models/visibility.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Visibility < ApplicationRecord
+  belongs_to :person
+  belongs_to :removed_by, class_name: "Officer"
+  belongs_to :created_by, class_name: "Officer"
+end

--- a/db/migrate/20161020200410_create_visibilities.rb
+++ b/db/migrate/20161020200410_create_visibilities.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# This migration creates a new table to track who is visible to patrol officers.
+# We are removing the `visible` column from `people` because,
+# as a boolean column,
+# it does not let us audit when plans were visible vs not.
+#
+# This migration is forgetful -
+# everyone will be transitioned to non-visible.
+# To correct this, we should run the RMS import script once.
+# The script will reset everybody's visibility.
+class CreateVisibilities < ActiveRecord::Migration[5.0]
+  def change
+    create_table :visibilities do |t|
+      t.belongs_to :person, foreign_key: true, null: false
+      t.text :creation_notes
+      t.belongs_to :created_by, foreign_key: { to_table: :officers }
+      t.datetime :removed_at
+      t.text :removal_notes
+      t.belongs_to :removed_by, foreign_key: { to_table: :officers }
+
+      t.timestamps
+    end
+
+    remove_index :people, :visible
+    remove_column :people, :visible, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161018225158) do
+ActiveRecord::Schema.define(version: 20161020200410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,8 +98,8 @@ ActiveRecord::Schema.define(version: 20161018225158) do
   end
 
   create_table "people", force: :cascade do |t|
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
     t.string   "first_name"
     t.string   "last_name"
     t.string   "sex"
@@ -113,9 +113,7 @@ ActiveRecord::Schema.define(version: 20161018225158) do
     t.string   "analytics_token"
     t.string   "location_name"
     t.string   "location_address"
-    t.boolean  "visible",          default: false, null: false
     t.string   "middle_initial"
-    t.index ["visible"], name: "index_people_on_visible", using: :btree
   end
 
   create_table "response_plans", force: :cascade do |t|
@@ -260,6 +258,20 @@ ActiveRecord::Schema.define(version: 20161018225158) do
     t.index ["response_plan_id"], name: "index_triggers_on_response_plan_id", using: :btree
   end
 
+  create_table "visibilities", force: :cascade do |t|
+    t.integer  "person_id"
+    t.text     "creation_notes"
+    t.integer  "created_by_id"
+    t.datetime "removed_at"
+    t.text     "removal_notes"
+    t.integer  "removed_by_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.index ["created_by_id"], name: "index_visibilities_on_created_by_id", using: :btree
+    t.index ["person_id"], name: "index_visibilities_on_person_id", using: :btree
+    t.index ["removed_by_id"], name: "index_visibilities_on_removed_by_id", using: :btree
+  end
+
   add_foreign_key "aliases", "people"
   add_foreign_key "contacts", "response_plans"
   add_foreign_key "deescalation_techniques", "response_plans"
@@ -275,4 +287,7 @@ ActiveRecord::Schema.define(version: 20161018225158) do
   add_foreign_key "suggestions", "officers"
   add_foreign_key "suggestions", "people"
   add_foreign_key "triggers", "response_plans"
+  add_foreign_key "visibilities", "officers", column: "created_by_id"
+  add_foreign_key "visibilities", "officers", column: "removed_by_id"
+  add_foreign_key "visibilities", "people"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -27,7 +27,7 @@ FactoryGirl.define do
     response_plan
   end
 
-  factory :officer, aliases: [:author, :approver] do
+  factory :officer, aliases: [:author, :approver, :created_by, :removed_by] do
     name "Johnson"
     phone "222-333-4444"
     sequence(:username) { |n| "officer_#{n}" }
@@ -55,7 +55,16 @@ FactoryGirl.define do
     hair_color "black"
     eye_color "blue"
     date_of_birth { 25.years.ago }
-    visible true
+
+    transient do
+      visible true
+    end
+
+    after(:create) do |person, evaluator|
+      if evaluator.visible
+        create(:visibility, person: person)
+      end
+    end
   end
 
   factory :response_plan, aliases: [:plan] do
@@ -128,5 +137,20 @@ FactoryGirl.define do
   factory :trigger do
     description "MyString"
     response_plan
+  end
+
+  factory :visibility do
+    person
+    created_by
+    creation_notes "Crossed incident threshold"
+    removed_at nil
+    removal_notes nil
+    removed_by nil
+
+    trait :removed do
+      removed_by
+      removed_at { Time.current }
+      removal_notes "They've moved away from Seattle"
+    end
   end
 end

--- a/spec/features/response_plan_lifecycle_spec.rb
+++ b/spec/features/response_plan_lifecycle_spec.rb
@@ -166,6 +166,7 @@ RSpec.feature "Response Plan Lifecycle" do
         expect(page).
           to have_content t("submissions.approve.success", name: person.name)
         expect(page).to have_content plan.background_info
+        expect(person.reload).to be_visible
       end
 
       scenario "they can kick a submission back down to draft status" do

--- a/spec/models/visibility_spec.rb
+++ b/spec/models/visibility_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Visibility, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Problem

We want to audit when people are visible to patrol officers,
and allow CRT to remove profiles from patrol view.
## Solution

Create a `Visibility` model
with `created_at` and `removed_at` attributes.
This model defines spans of time
during which people are visible to patrol officers.

The model also has fields for descriptions,
which will be useful when CRT manually adds or removes visibility.
## To do
- Add a UI flow for CRT officers to add or remove visibility
  for a person
