### PR TITLE
Send email to CRT when someone crosses threshold

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -6,7 +6,7 @@
 ADMINISTRATOR_CONTACT_PHONE=206-615-0226
 APPLICATION_HOST=localhost
 ASSET_HOST=localhost:3000
-CONTENT_SUGGESTION_EMAIL=seattle@codeforamerica.org
+CONTENT_ADMIN_EMAIL=seattle@codeforamerica.org
 DB_HOST=db
 DB_USER=postgres
 DEMO_MODE=false

--- a/app/mailers/suggestion_mailer.rb
+++ b/app/mailers/suggestion_mailer.rb
@@ -12,6 +12,6 @@ class SuggestionMailer < ApplicationMailer
       subject = URGENT_PREFIX + subject
     end
 
-    mail(to: ENV.fetch("CONTENT_SUGGESTION_EMAIL"), subject: subject)
+    mail(to: ENV.fetch("CONTENT_ADMIN_EMAIL"), subject: subject)
   end
 end

--- a/app/mailers/visibility_mailer.rb
+++ b/app/mailers/visibility_mailer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class VisibilityMailer < ApplicationMailer
+  def crossed_threshold(visibility)
+    @person = visibility.person
+    date = visibility.created_at.to_date
+
+    mail(
+      to: ENV.fetch("FEEDBACK_EMAIL"),
+      subject: "[RideAlong Response] New Core Profile Generated - #{l(date)}",
+    )
+  end
+end

--- a/app/views/sections/_print_about.html.erb
+++ b/app/views/sections/_print_about.html.erb
@@ -8,7 +8,7 @@
 
     <p>
     If you have any suggestions for how to improve this plan,
-    please contact <%= mail_to ENV.fetch("CONTENT_SUGGESTION_EMAIL") %>.
+    please contact <%= mail_to ENV.fetch("CONTENT_ADMIN_EMAIL") %>.
     </p>
   </div>
 </section>

--- a/app/views/visibility_mailer/crossed_threshold.html.erb
+++ b/app/views/visibility_mailer/crossed_threshold.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    A new core profile has been generated.
+
+    <h1><%= @person.name %></h1>
+    <h2><%= l(@person.date_of_birth) %></h2>
+
+    <div>
+      Core profiles are generated once a person has had at least
+      <%= ENV.fetch("RECENT_CRISIS_INCIDENT_THRESHOLD") %>
+      crisis incident templates filled out within the past 365 days.
+    </div>
+
+    <%= link_to "View Core Profile", person_url(@person) %>
+  </body>
+</html>

--- a/spec/lib/rms_importer_spec.rb
+++ b/spec/lib/rms_importer_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 require "rms_importer"
+require "email_service"
 
 describe RMSImporter do
   it "uses the credentials stored in the ENV variables" do
@@ -211,6 +212,7 @@ describe RMSImporter do
         allow(ENV).to receive(:fetch).
           with("RECENT_CRISIS_INCIDENT_THRESHOLD").
           and_return(1)
+        allow(EmailService).to receive(:send)
 
         person = create(:person, visible: false)
         rms_person = create(:rms_person, person: person)
@@ -226,6 +228,11 @@ describe RMSImporter do
         expect(visibility.creation_notes).
           to eq("[AUTO] Person crossed the threshold of 1 RMS Crisis Incident")
         expect(person.reload).to be_visible
+
+        expect(EmailService).to have_received(:send) do |message|
+          expect(message.subject).
+            to eq("[RideAlong Response] New Core Profile Generated - #{l(Date.today)}")
+        end
       end
     end
 

--- a/spec/mailers/suggestion_mailer_spec.rb
+++ b/spec/mailers/suggestion_mailer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SuggestionMailer, type: :mailer do
     it "pulls the recipients from the ENV variable" do
       recipients = ["foo@bar.com", "baz@bar.com"]
       allow(ENV).to receive(:fetch).
-        with("CONTENT_SUGGESTION_EMAIL").
+        with("CONTENT_ADMIN_EMAIL").
         and_return(recipients.join(","))
 
       mail = SuggestionMailer.created(create(:suggestion))

--- a/spec/mailers/visibility_spec.rb
+++ b/spec/mailers/visibility_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe VisibilityMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Problem

CRT does not get any notice when a new person is automatically added to
the application.

## Solution

Send an email to the address specified in `CONTENT_ADMIN_EMAIL` with a
link to the new person's profile.

## Migrate

* Rename the `CONTENT_SUGGESTION_EMAIL` env variable
  to `CONTENT_ADMIN_EMAIL`
* Run the import with a dummy `CONTENT_SUGGESTION_EMAIL` so CRT does not
  get spammed