### PR TITLE
Immediately publish approved response plans

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -41,6 +41,7 @@ class SubmissionsController < ApplicationController
       flashes = { alert: t(".failure.not_submitted", name: plan.person.name) }
     else
       plan.update!(approver: current_officer)
+      create_approval_visibility(plan.person)
       flashes = { notice: t(".success", name: plan.person.name) }
     end
 
@@ -57,6 +58,18 @@ class SubmissionsController < ApplicationController
       redirect_to draft_path(plan), notice: t(".success", name: plan.person.name)
     else
       redirect_to person_path(plan.person), alert: t(".failure")
+    end
+  end
+
+  private
+
+  def create_approval_visibility(person)
+    unless person.visible?
+      Visibility.create!(
+        person: person,
+        created_by: current_officer,
+        creation_notes: "A response plan was approved and published to patrol",
+      )
     end
   end
 end

--- a/spec/features/response_plan_lifecycle_spec.rb
+++ b/spec/features/response_plan_lifecycle_spec.rb
@@ -181,6 +181,22 @@ RSpec.feature "Response Plan Lifecycle" do
         expect(current_path).to eq draft_path(plan)
         expect(page).to have_link t("drafts.show.edit")
       end
+
+      scenario "approved plans are immediately visible" do
+        officer = create(:officer, :admin)
+        person = create(:person, visible: false)
+        plan = create(:response_plan, :submission, person: person)
+
+        sign_in_officer(officer)
+        visit submission_path(plan)
+        click_on t("submissions.show.approve")
+
+        visibility = Visibility.last
+        expect(person.reload).to be_visible
+        expect(visibility.creation_notes).
+          to eq("A response plan was approved and published to patrol")
+        expect(visibility.created_by).to eq(officer)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

Response plans approved for distribution to patrol officers
weren't automatically being published.
CRT had to manually publish them.

## Solution

Automatically create a visibility for a person when a response plan is
approved for them.