### PR TITLE
Add Fuubar for better testing output

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
+--format Fuubar
 --color
---require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem "bundler-audit", require: false
   gem "dotenv-rails"
   gem "factory_girl_rails"
+  gem "fuubar"
   gem "pry-byebug"
   gem "pry-rails"
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
       activesupport
       capybara
       i18n
+    fuubar (2.2.0)
+      rspec-core (~> 3.0)
+      ruby-progressbar (~> 1.4)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)
@@ -222,6 +225,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     ruby-oci8 (2.2.2)
+    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -294,6 +298,7 @@ DEPENDENCIES
   factory_girl_rails
   flutie
   formulaic
+  fuubar
   high_voltage
   inline_svg
   kaminari


### PR DESCRIPTION
## Problem

With the default test formatter,
you cannot see the reason for failures until the entire test suite ends.
This really slows down the development/test feedback cycle.

## Solution

Fuubar is a formatter that displays failures instantly.
It has some nice additional features
like a progress bar and time estimates.