### PR TITLE
Auto-remove people who drop below threshold

### DIFF
--- a/app/controllers/visibilities_controller.rb
+++ b/app/controllers/visibilities_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "threshold"
+
 class VisibilitiesController < ApplicationController
   before_action :authenticate_officer!
   before_action :authorize_admin

--- a/app/models/visibility.rb
+++ b/app/models/visibility.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# If `created_by` or `removed_by` are nil,
+# we assume that the visibility was automatically created or removed
+# by the RMS import script.
 class Visibility < ApplicationRecord
   belongs_to :person
   belongs_to :removed_by, class_name: "Officer"
@@ -7,11 +10,13 @@ class Visibility < ApplicationRecord
 
   validates :person, presence: true
   validates :creation_notes, presence: true
-
-  validates :removed_by, presence: true, if: -> { removed_at.present? }
   validates :removal_notes, presence: true, if: -> { removed_at.present? }
 
   def self.active
     where(removed_at: nil)
+  end
+
+  def removed_automatically?
+    removed_at.present? && removed_by.nil?
   end
 end

--- a/app/views/visibilities/edit.html.erb
+++ b/app/views/visibilities/edit.html.erb
@@ -1,9 +1,31 @@
 <section class="visibility solo-page">
-  <div class="section-header">
+  <div class="section-header section-header-blue-inverted">
     Hide <%= @visibility.person.name %>'s profile from patrol officers.
   </div>
 
   <div class="section-body">
+    <p>
+    WARNING!
+    </p>
+
+    <p>
+    This action has irreversible side effects.
+    </p>
+
+    <p>
+    <%= @visibility.person.name %>'s profile will stop
+    being automatically shown and hidden
+    based on their crisis incidents.
+    If they rise above
+    <%= pluralize(Threshold::DEFAULT_THRESHOLD, "incidents") %> in a year,
+    they will still be hidden from patrol officers.
+    </p>
+
+    <p>
+    Their profile will only be shown to patrol officers
+    once a CRT officer manually makes them visible.
+    </p>
+
     <%= simple_form_for @visibility, url: person_visibility_path(person_id: @visibility.person_id) do |f| %>
       <%= f.input :removal_notes, label: "Notes", required: true %>
       <%= f.submit %>

--- a/app/views/visibilities/new.html.erb
+++ b/app/views/visibilities/new.html.erb
@@ -1,9 +1,31 @@
 <section class="visibility solo-page">
-  <div class="section-header">
+  <div class="section-header section-header-blue-inverted">
     Make <%= @visibility.person.name %>'s profile visible to patrol officers.
   </div>
 
   <div class="section-body">
+    <p>
+    WARNING!
+    </p>
+
+    <p>
+    This action has irreversible side effects.
+    </p>
+
+    <p>
+    <%= @visibility.person.name %>'s profile will stop
+    being automatically shown and hidden
+    based on their crisis incidents.
+    If they drop below
+    <%= pluralize(Threshold::DEFAULT_THRESHOLD, "incidents") %> in a year,
+    they will still be shown to patrol officers.
+    </p>
+
+    <p>
+    Their profile will only be hidden from patrol officers
+    once a CRT officer manually removes them.
+    </p>
+
     <%= simple_form_for @visibility, url: person_visibility_path(person_id: @visibility.person_id) do |f| %>
       <%= f.input :creation_notes, label: "Notes" %>
       <%= f.submit %>

--- a/lib/threshold.rb
+++ b/lib/threshold.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "action_view/helpers/text_helper"
+
+class Threshold
+  include ActionView::Helpers::TextHelper
+
+  DEFAULT_THRESHOLD = ENV.fetch("RECENT_CRISIS_INCIDENT_THRESHOLD").to_i
+
+  def initialize(threshold = DEFAULT_THRESHOLD)
+    @threshold = threshold
+  end
+
+  attr_reader :threshold
+
+  def create_visibilities_over_threshold
+    new_visibilities = []
+
+    new_people_over_threshold.each do |person_id|
+      new_visibilities << Visibility.create!(
+        person_id: person_id,
+        creation_notes: crossed_threshold_message,
+      )
+    end
+
+    new_visibilities
+  end
+
+  # Limit this method to `where(created_by: nil)`
+  # so that we don't remove someone that CRT has manually marked as visible.
+  def remove_visibilities_below_threshold
+    Visibility.
+      active.
+      where(created_by: nil, person_id: people_ids_under_threshold).
+      each do |visibility|
+        visibility.update!(
+          removed_by: nil,
+          removal_notes: crossed_threshold_message,
+          removed_at: Time.current,
+        )
+      end
+  end
+
+  private
+
+  def new_people_over_threshold
+    people_ids_over_threshold -
+      people_with_current_visibility -
+      people_with_manually_removed_visibility
+  end
+
+  def people_ids_over_threshold
+    RMS::Person.
+      where(id: rms_people_ids_over_threshold).
+      pluck(:person_id)
+  end
+
+  def people_with_current_visibility
+    Visibility.active.pluck(:person_id).uniq
+  end
+
+  def people_with_manually_removed_visibility
+    Visibility.
+      where.not(removed_by: nil).
+      pluck(:person_id)
+  end
+
+  def rms_people_ids_over_threshold
+    rms_people_incident_counts.
+      select { |_, incident_count| incident_count >= threshold }.
+      keys
+  end
+
+  def manually_visible_people_ids
+    Visibility.active.where.not(created_by: nil).pluck(:person_id).uniq
+  end
+
+  def people_ids_under_threshold
+    Person.
+      where.not(id: people_ids_over_threshold).
+      pluck(:id)
+  end
+
+  def rms_people_incident_counts
+    RMS::CrisisIncident.
+      where(reported_at: (Person::RECENT_TIMEFRAME.ago..Time.current)).
+      group(:rms_person_id).
+      count
+  end
+
+  def crossed_threshold_message
+    threshold_text = pluralize(threshold, "RMS Crisis Incident")
+    "[AUTO] Person crossed the threshold of #{threshold_text}"
+  end
+end

--- a/spec/lib/threshold_spec.rb
+++ b/spec/lib/threshold_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "threshold"
+
+describe Threshold do
+  context "when the person has not been visible before" do
+    it "makes them visible to patrol officers" do
+      person = create(:person, visible: false)
+      rms_person = create(:rms_person, person: person)
+      create(:incident, rms_person: rms_person)
+
+      expect do
+        Threshold.new(1).create_visibilities_over_threshold
+      end.to change(Visibility, :count).by(1)
+
+      visibility = Visibility.last
+      expect(visibility.person).to eq(person)
+      expect(visibility.creation_notes).
+        to eq("[AUTO] Person crossed the threshold of 1 RMS Crisis Incident")
+      expect(person.reload).to be_visible
+    end
+  end
+
+  context "when the person has been manually set to visible" do
+    it "doesn't change their visibility" do
+      person = create(:person)
+      visibility = create(:visibility, person: person, created_by: nil)
+
+      expect do
+        Threshold.new.remove_visibilities_below_threshold
+      end.not_to change(Visibility, :count)
+
+      expect(visibility.person).to eq(person)
+      expect(person.reload).to be_visible
+    end
+  end
+
+  context "when the person has been automatically removed from visiblity" do
+    it "updates their visibility" do
+      person = create(:person, visible: false)
+      rms_person = create(:rms_person, person: person)
+      create(:incident, rms_person: rms_person)
+      create(:visibility, :removed, person: person, removed_by: nil)
+
+      expect do
+        Threshold.new(1).create_visibilities_over_threshold
+      end.to change(Visibility, :count)
+
+      expect(person.reload).to be_visible
+    end
+  end
+
+  context "when a person has been manually removed from visibility" do
+    it "does not update their visibility" do
+      incident = create(:incident)
+      person = create(:person, rms_person: incident.rms_person, visible: false)
+      create(
+        :visibility,
+        :removed,
+        person: person,
+        removed_by: create(:officer),
+      )
+
+      expect do
+        Threshold.new(1).create_visibilities_over_threshold
+      end.not_to change(Visibility, :count)
+
+      expect(person.reload).not_to be_visible
+    end
+  end
+
+  context "when the person has automatically been marked as visible" do
+    it "removes their visibility" do
+      person = create(:person, visible: false)
+      visibility = create(:visibility, created_by: nil, person: person)
+
+      Threshold.new.remove_visibilities_below_threshold
+
+      expect(person.reload).not_to be_visible
+      expect(visibility.reload).to be_removed_automatically
+    end
+  end
+end

--- a/spec/models/visibility_spec.rb
+++ b/spec/models/visibility_spec.rb
@@ -18,14 +18,33 @@ RSpec.describe Visibility, type: :model do
       expect(visibility.errors[:removal_notes]).to be_empty
     end
 
-    it "requires `removed_by` and `removal_notes` if `removed_at` is set" do
+    it "requires `removal_notes` if `removed_at` is set" do
       visibility = build(:visibility)
 
       visibility.removed_at = Time.current
 
       expect(visibility).not_to be_valid
       expect(visibility.errors[:removal_notes]).to include("can't be blank")
-      expect(visibility.errors[:removed_by]).to include("can't be blank")
+    end
+  end
+
+  describe "removed_automatically?" do
+    it "is true if there is no remover" do
+      visibility = build(:visibility, :removed, removed_by: nil)
+
+      expect(visibility).to be_removed_automatically
+    end
+
+    it "is false if it was removed by an offier" do
+      visibility = build(:visibility, :removed, removed_by: create(:officer))
+
+      expect(visibility).not_to be_removed_automatically
+    end
+
+    it "is false if it is not removed" do
+      visibility = build(:visibility)
+
+      expect(visibility).not_to be_removed_automatically
     end
   end
 end


### PR DESCRIPTION
If a person above the crisis incident threshold
stops having frequent incidents,
they can drop back below the threshold of 7 calls in the past 365 days.

Previously, a CRT officer had to manually remove the person from view.
Now, they should be removed from view automatically.

This is a bit of a tricky setup,
because we don't want importing
to overwrite the actions of a CRT officer.

For example, if a CRT officer makes someone with fewer than 7 calls visible,
we don't want importing to hide them the next time it runs.

Here's an outline of situations and their outcomes:
- Person is visible
  - they were automatically made visible
    - they cross below the threshold: HIDDEN
    - they are manually hidden by CRT: HIDDEN
  - they were manually made visible by CRT
    - they cross below the threshold: VISIBLE
    - they are manually hidden by CRT: HIDDEN
- Person is hidden
  - they were automatically hidden
    - they cross above the threshold: VISIBLE
    - they are manually shared w/ patrol by CRT: VISIBLE
  - they were manually hidden by CRT
    - they cross above the threshold: HIDDEN
    - they are manually shared w/ patrol by CRT: VISIBLE

As you can see, CRT's input overrides everything.
A side effect of this
is that when CRT marks someone as visible or hidden,
the automatic process will no longer apply to them.
CRT will need to be responsible for managing the person's visibility
from that point onwards.

We should look at adding help text in the application
to explain that side effect.
