### PR TITLE
Move JS from <head> to bottom of <body>

### DIFF
--- a/app/assets/javascripts/application/date_inputs.js
+++ b/app/assets/javascripts/application/date_inputs.js
@@ -8,6 +8,6 @@ $(function() {
         autoclear: false
       });
   }
-});
 
-$(window.mask_date_fields);
+  window.mask_date_fields();
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,6 @@
   <link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
   <link rel="manifest" href="/manifest.json">
   <%= csrf_meta_tags %>
-  <%= render "javascript" %>
 </head>
 
 <body>
@@ -27,5 +26,7 @@
   </div>
   <%= render "footer" %>
   <%= render "menu" %>
+
+  <%= render "javascript" %>
 </body>
 </html>


### PR DESCRIPTION
## Problem

Our JS was running before the DOM loaded,
which meant that some JS that modified DOM elements
(such as date input field masks)
would some DOM elements they were supposed to modify.

## Solution

Move the JS include tag to the bottom of the page,
so the DOM is always loaded before it executes.