### PR TITLE
Turn footer into a floating action button

### DIFF
--- a/app/assets/images/feedback.svg
+++ b/app/assets/images/feedback.svg
@@ -1,0 +1,3 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z"/>
+</svg>

--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -1,17 +1,57 @@
+$fab-size: 2 * $base-spacing;
+
 .footer {
-  background-color: $header-background-color;
+  @include icon-color($fab-icon-color);
+  background-color: $fab-background-color;
+  border-radius: 50%;
   bottom: 0;
+  bottom: $base-spacing;
   box-shadow: $shadow-level-4;
-  color: $header-font-color;
+  display: block;
   font-size: 1rem;
+  height: $fab-size;
   padding: $small-spacing;
   position: fixed;
-  display: block;
-  width: 100%;
+  right: $base-spacing;
+  width: $fab-size;
   z-index: 1;
-}
 
-.footer-content {
-  margin: auto;
-  width: $page-width;
+  svg {
+    height: 100%;
+    width: 100%;
+  }
+
+  &:after,
+  &:before {
+    opacity: 0;
+    transition: opacity $base-duration $base-timing;
+  }
+
+  &:before {
+    background-color: $fab-callout-background-color;
+    border-radius: 4px;
+    bottom: 0;
+    box-shadow: $shadow-level-4;
+    color: $fab-callout-text-color;
+    content: "Leave Feedback";
+    display: block;
+    padding: $small-spacing;
+    position: absolute;
+    right: $fab-size + $base-spacing;
+    white-space: nowrap;
+  }
+
+  &:after {
+    content: "";
+    position: absolute;
+    right: $fab-size;
+    border: $small-spacing solid transparent;
+    border-left: calc(#{$small-spacing} + 1px) solid $fab-callout-background-color;
+    bottom: 25%;
+  }
+
+  &:hover:before,
+  &:hover:after {
+    opacity: 1;
+  }
 }

--- a/app/assets/stylesheets/themes/_day.scss
+++ b/app/assets/stylesheets/themes/_day.scss
@@ -81,3 +81,9 @@ $needs_approval-text-color: $base-font-color;
 
 // Timeline
 $timeline-color: $dark-gray;
+
+// Floating Action Button
+$fab-background-color: $action-color;
+$fab-icon-color: $white;
+$fab-callout-background-color: $dark-gray;
+$fab-callout-text-color: $white;

--- a/app/assets/stylesheets/themes/_night.scss
+++ b/app/assets/stylesheets/themes/_night.scss
@@ -83,3 +83,9 @@ $needs_approval-text-color: $dark-gray;
 
 // Timeline
 $timeline-color: $white;
+
+// Floating Action Button
+$fab-background-color: $action-color;
+$fab-icon-color: $white;
+$fab-callout-background-color: $dark-gray;
+$fab-callout-text-color: $white;

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,5 +1,3 @@
 <%= link_to new_feedback_path, class: "footer" do %>
-  <div class="footer-content">
-    Leave Feedback
-  </div>
+  <%= inline_svg("feedback.svg") %>
 <% end %>

--- a/spec/features/officer_leaves_feedback_spec.rb
+++ b/spec/features/officer_leaves_feedback_spec.rb
@@ -8,7 +8,7 @@ feature "Feedback" do
     response_plan = create(:response_plan)
 
     visit person_path(response_plan.person)
-    click_on "Leave Feedback"
+    find(".footer").click
     fill_in :feedback_name, with: "Sandlin Grayson"
     fill_in :feedback_description, with: "foobar"
     click_on "Submit Feedback"


### PR DESCRIPTION
This reapplies #311.

The footer took up a large amount of screen space,
especially on mobile devices.
It is no longer included in the mocks.