### PR TITLE
Fix up visibility email links & recipients

### DIFF
--- a/app/mailers/visibility_mailer.rb
+++ b/app/mailers/visibility_mailer.rb
@@ -6,7 +6,7 @@ class VisibilityMailer < ApplicationMailer
     date = visibility.created_at.to_date
 
     mail(
-      to: ENV.fetch("FEEDBACK_EMAIL"),
+      to: ENV.fetch("CONTENT_ADMIN_EMAIL"),
       subject: "[RideAlong Response] New Core Profile Generated - #{l(date)}",
     )
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.assets.quiet = true
   config.assets.raise_runtime_errors = true
   config.action_view.raise_on_missing_translations = true
-  config.action_mailer.default_url_options = { host: "localhost:3000" }
+  config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST") }
   config.action_controller.perform_caching = true
   config.cache_store = :mem_cache_store, "cache"
 


### PR DESCRIPTION
## Problem

Messages about people who were newly visible in the app
were going to the email for feedback on the app itself
(i.e., technical staff).

The link included in the email was incorrect,
using `localhost:3000` instead of the actual application's host URL.